### PR TITLE
Make linux compatible

### DIFF
--- a/Master/Itho/CC1101Packet.h
+++ b/Master/Itho/CC1101Packet.h
@@ -7,7 +7,7 @@
 
 #include <stdio.h>
 #ifdef ESP8266
-#include <arduino.h>
+#include <Arduino.h>
 #endif
 
 #define CC1101_BUFFER_LEN        64

--- a/Master/Itho/IthoCC1101.h
+++ b/Master/Itho/IthoCC1101.h
@@ -59,7 +59,7 @@ const uint8_t counterBytes66[] = {170,106};
 
 
 //state machine
-typedef enum IthoReceiveStates
+enum IthoReceiveStates
 {
 	ExpectMessageStart,
 	ExpectNormalCommand,

--- a/Master/Itho/IthoPacket.h
+++ b/Master/Itho/IthoPacket.h
@@ -6,13 +6,13 @@
 #define ITHOPACKET_H_
 
 
-typedef enum IthoMessageType
- {
+enum IthoMessageType
+{
  	ithomsg_unknown = 0,
  	ithomsg_control = 1,
  	ithomsg_join = 2,
  	ithomsg_leave = 3
- };
+};
  
  //do not change enum because they are used in calculations!
 enum IthoCommand


### PR DESCRIPTION
Thanks for this great open source project to control the 'ITHO Eco Fan RFT' using the 'ESP8266'!

To let it compile in Arduino (1.8.5), running at Ubuntu (17.10), I made two small commits.
I hope you will integrate these into the 'master'.

Bugfix: Linux is case sensitive - Include Arduino.h instead of arduino.h
Bugfix: Without the typedef name, the keyword typedef is superfluous 