### PR TITLE
Restore receive performance and add support for RFT AUTO CO2 remote

### DIFF
--- a/Master/Itho/IthoCC1101.cpp
+++ b/Master/Itho/IthoCC1101.cpp
@@ -88,7 +88,7 @@ void IthoCC1101::initSendMessage1()
 	writeRegister(CC1101_CHANNR ,0x00);		//00000000
 	writeRegister(CC1101_DEVIATN ,0x40);	//01000000
 	writeRegister(CC1101_FREND0 ,0x17);		//00010111	use index 7 in PA table
-	writeRegister(CC1101_MCSM0 ,0x18);		//00011000	PO timeout Approx. 146µs - 171µs, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
+	writeRegister(CC1101_MCSM0 ,0x18);		//00011000	PO timeout Approx. 146Âµs - 171Âµs, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
 	writeRegister(CC1101_FSCAL3 ,0xA9);		//10101001
 	writeRegister(CC1101_FSCAL2 ,0x2A);		//00101010
 	writeRegister(CC1101_FSCAL1 ,0x00);		//00000000
@@ -176,7 +176,7 @@ void IthoCC1101::initSendMessage2(IthoCommand command)
 	writeRegister(CC1101_CHANNR ,0x00);		//00000000
 	writeRegister(CC1101_DEVIATN ,0x50);	//difference compared to message1
 	writeRegister(CC1101_FREND0 ,0x17);		//00010111	use index 7 in PA table
-	writeRegister(CC1101_MCSM0 ,0x18);		//00011000	PO timeout Approx. 146µs - 171µs, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
+	writeRegister(CC1101_MCSM0 ,0x18);		//00011000	PO timeout Approx. 146Âµs - 171Âµs, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
 	writeRegister(CC1101_FSCAL3 ,0xA9);		//10101001
 	writeRegister(CC1101_FSCAL2 ,0x2A);		//00101010
 	writeRegister(CC1101_FSCAL1 ,0x00);		//00000000
@@ -283,7 +283,7 @@ void IthoCC1101::initReceive()
 	writeRegister(CC1101_FREQ1 ,0x65);
 	writeRegister(CC1101_FREQ0 ,0x6A);
 	writeRegister(CC1101_IOCFG0 ,0x2E);			//High impedance (3-state)
-	writeRegister(CC1101_IOCFG2 ,0x00);			//Assert when RX FIFO is filled or above the RX FIFO threshold. Deassert when (0x00): RX FIFO is drained below threshold, or (0x01): deassert when RX FIFO is empty.
+	writeRegister(CC1101_IOCFG2 ,0x06);			//0x06 Assert when sync word has been sent / received, and de-asserts at the end of the packet. 
 	writeRegister(CC1101_FSCTRL1 ,0x06);
 	writeRegister(CC1101_FSCTRL0 ,0x00);
 	writeRegister(CC1101_MDMCFG4 ,0x5A);

--- a/Master/Itho/IthoCC1101.cpp
+++ b/Master/Itho/IthoCC1101.cpp
@@ -286,13 +286,13 @@ void IthoCC1101::initReceive()
 	writeRegister(CC1101_IOCFG2 ,0x00);			//Assert when RX FIFO is filled or above the RX FIFO threshold. Deassert when (0x00): RX FIFO is drained below threshold, or (0x01): deassert when RX FIFO is empty.
 	writeRegister(CC1101_FSCTRL1 ,0x06);
 	writeRegister(CC1101_FSCTRL0 ,0x00);
-	writeRegister(CC1101_MDMCFG4 ,0xE8);
-	writeRegister(CC1101_MDMCFG3 ,0x43);
+	writeRegister(CC1101_MDMCFG4 ,0x5A);
+	writeRegister(CC1101_MDMCFG3 ,0x83);
 	writeRegister(CC1101_MDMCFG2 ,0x00);		//Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync 
 	writeRegister(CC1101_MDMCFG1 ,0x22);		//Disable FEC
 	writeRegister(CC1101_MDMCFG0 ,0xF8);
 	writeRegister(CC1101_CHANNR ,0x00);
-	writeRegister(CC1101_DEVIATN ,0x40);
+	writeRegister(CC1101_DEVIATN ,0x50);
 	writeRegister(CC1101_FREND1 ,0x56);
 	writeRegister(CC1101_FREND0 ,0x17);
 	writeRegister(CC1101_MCSM0 ,0x18);			//no auto calibrate
@@ -301,10 +301,10 @@ void IthoCC1101::initReceive()
 	writeRegister(CC1101_AGCCTRL2 ,0x43);
 	writeRegister(CC1101_AGCCTRL1 ,0x40);
 	writeRegister(CC1101_AGCCTRL0 ,0x91);
-	writeRegister(CC1101_FSCAL3 ,0xA9);
+	writeRegister(CC1101_FSCAL3 ,0xE9);
 	writeRegister(CC1101_FSCAL2 ,0x2A);
 	writeRegister(CC1101_FSCAL1 ,0x00);
-	writeRegister(CC1101_FSCAL0 ,0x1F);
+	writeRegister(CC1101_FSCAL0 ,0x11);
 	writeRegister(CC1101_FSTEST ,0x59);
 	writeRegister(CC1101_TEST2 ,0x81);
 	writeRegister(CC1101_TEST1 ,0x35);
@@ -344,7 +344,7 @@ void  IthoCC1101::initReceiveMessage2(IthoMessageType expectedMessageType)
 	writeCommand(CC1101_SIDLE);	//idle
 	
 	//set datarate	
-	writeRegister(CC1101_MDMCFG4 ,0x9A); // set kBaud
+	writeRegister(CC1101_MDMCFG4 ,0x5A); // set kBaud
 	writeRegister(CC1101_MDMCFG3 ,0x83); // set kBaud
 	writeRegister(CC1101_DEVIATN ,0x50);
 	
@@ -392,6 +392,7 @@ void IthoCC1101::parseMessageCommand()
 	bool isTimer2Command = true;
 	bool isTimer3Command = true;
 	bool isJoinCommand = true;
+	bool isJoin2Command = true;
 	bool isLeaveCommand = true;
 
 	//device id
@@ -413,6 +414,7 @@ void IthoCC1101::parseMessageCommand()
 		if (inMessage2.data[i+18] != ithoMessage2Timer2CommandBytes[i])  isTimer2Command = false;
 		if (inMessage2.data[i+18] != ithoMessage2Timer3CommandBytes[i])  isTimer3Command = false;
 		if (inMessage2.data[i+18] != ithoMessage2JoinCommandBytes[i])    isJoinCommand = false;
+		if (inMessage2.data[i + 18] != ithoMessage2Join2CommandBytes[i])   isJoin2Command = false;
 		if (inMessage2.data[i+18] != ithoMessage2LeaveCommandBytes[i])   isLeaveCommand = false;
 	}	
 		
@@ -427,6 +429,7 @@ void IthoCC1101::parseMessageCommand()
 	if (isTimer2Command)  inIthoPacket.command = IthoTimer2;
 	if (isTimer3Command)  inIthoPacket.command = IthoTimer3;
 	if (isJoinCommand)    inIthoPacket.command = IthoJoin;
+	if (isJoin2Command)   inIthoPacket.command = IthoJoin;
 	if (isLeaveCommand)   inIthoPacket.command = IthoLeave;	
 }
 

--- a/Master/Itho/IthoCC1101.h
+++ b/Master/Itho/IthoCC1101.h
@@ -42,6 +42,7 @@ const uint8_t ithoMessage2Timer1CommandBytes[] = {6,89,150,170,169,101,90,150,85
 const uint8_t ithoMessage2Timer2CommandBytes[] = {6,89,150,170,169,101,90,150,85,149,101,89,86,149,150};	//20 minutes full speed
 const uint8_t ithoMessage2Timer3CommandBytes[] = {6,89,150,170,169,101,90,150,85,149,101,89,86,149,154};	//30 minutes full speed
 const uint8_t ithoMessage2JoinCommandBytes[] = {9,90,170,90,165,165,89,106,85,149,102,89,150,170,165};
+const uint8_t ithoMessage2Join2CommandBytes[] = {9,90,170,90,165,165,89,106,105,169,102,89,150,170,149};  //join command of RFT AUTO Co2 remote
 const uint8_t ithoMessage2LeaveCommandBytes[] = {9,90,170,90,165,165,89,166,85,149,105,90,170,90,165};
 
 //message 2, counter

--- a/Master/IthoEcoFanRFT/IthoEcoFanRFT.ino
+++ b/Master/IthoEcoFanRFT/IthoEcoFanRFT.ino
@@ -27,13 +27,11 @@
 #include <SPI.h>
 #include "IthoCC1101.h"
 #include "IthoPacket.h"
-#include <Ticker.h>
 
 #define ITHO_IRQ_PIN D2
 
 IthoCC1101 rf;
 IthoPacket packet;
-Ticker ITHOticker;
 
 const uint8_t RFTid[] = {106, 170, 106, 101, 154, 107, 154, 86}; // my ID
 
@@ -55,7 +53,7 @@ void setup(void) {
   sendRegister();
   Serial.println("join command sent");
   pinMode(ITHO_IRQ_PIN, INPUT);
-  attachInterrupt(ITHO_IRQ_PIN, ITHOinterrupt, RISING);
+  attachInterrupt(ITHO_IRQ_PIN, ITHOcheck, FALLING);
 }
 
 void loop(void) {
@@ -65,11 +63,7 @@ void loop(void) {
   }
 }
 
-void ITHOinterrupt() {
-  ITHOticker.once_ms(10, ITHOcheck);
-}
-
-void ITHOcheck() {
+ICACHE_RAM_ATTR void ITHOcheck() {
   if (rf.checkForNewPacket()) {
     IthoCommand cmd = rf.getLastCommand();
     if (++RFTcommandpos > 2) RFTcommandpos = 0;  // store information in next entry of ringbuffers


### PR DESCRIPTION
Restore receive performance and add support for RFT AUTO CO2 remote

- Receive performance decreased since last PR, especially for the itho RFT AUTO CO2 remote
- The itho RFT AUTO CO2 uses a different join command, this command has been added to be able to receive this command from this type of remote

Edit: I see both commits ended up in the PR, probably my inexperience with Github sorry

Second commit changes:
- Add ICACHE_RAM_ATTR to ISR ITHOcheck() to place function in IRAM
- Assert GDO2 when sync word has been sent / received, and de-assert at the end of the packet. this way the ISR can trigger on the FALLING edge and there is no need anymore for the 10ms timer and ticker lib
