### PR TITLE
Rework of the itho packet section, cleanup and easier to understand, improved stability

### DIFF
--- a/Master/Itho/CC1101.cpp
+++ b/Master/Itho/CC1101.cpp
@@ -206,6 +206,9 @@ uint8_t CC1101::receiveData(CC1101Packet* packet, uint8_t length)
 	{
 		//empty fifo
 		packet->length = 0;
+		writeCommand(CC1101_SIDLE); //idle    
+		writeCommand(CC1101_SFRX); //flush RX buffer
+		writeCommand(CC1101_SRX); //switch to RX state     		
 	}
 
 	return packet->length;

--- a/Master/Itho/CC1101.cpp
+++ b/Master/Itho/CC1101.cpp
@@ -1,16 +1,14 @@
 /*
- * Author: Klusjesman, modified bij supersjimmie for Arduino/ESP8266
- */
+   Author: Klusjesman, modified bij supersjimmie for Arduino/ESP8266
+*/
 
 #include "CC1101.h"
 
 // default constructor
 CC1101::CC1101()
 {
-	SPI.begin();
-#ifdef ESP8266
-	pinMode(SS, OUTPUT);
-#endif
+  SPI.begin();
+  pinMode(SS, OUTPUT);
 } //CC1101
 
 // default destructor
@@ -21,72 +19,72 @@ CC1101::~CC1101()
 /***********************/
 // SPI helper functions select() and deselect()
 inline void CC1101::select(void) {
-	digitalWrite(SS, LOW);
+  digitalWrite(SS, LOW);
 }
 
 inline void CC1101::deselect(void) {
-	digitalWrite(SS, HIGH);
+  digitalWrite(SS, HIGH);
 }
 
 void CC1101::spi_waitMiso()
 {
-    while(digitalRead(MISO) == HIGH) yield();
+  while (digitalRead(MISO) == HIGH) yield();
 }
 
 void CC1101::init()
 {
-	reset();
+  reset();
 }
 
 void CC1101::reset()
 {
-	deselect();
-	delayMicroseconds(5);
-	select();
-	delayMicroseconds(10);
-	deselect();
-	delayMicroseconds(45);
-	select();
+  deselect();
+  delayMicroseconds(5);
+  select();
+  delayMicroseconds(10);
+  deselect();
+  delayMicroseconds(45);
+  select();
 
-	spi_waitMiso();
-	SPI.transfer(CC1101_SRES);
-	delay(10);
-	spi_waitMiso();
-	deselect();
+  spi_waitMiso();
+  SPI.transfer(CC1101_SRES);
+  delay(10);
+  spi_waitMiso();
+  deselect();
 }
 
-uint8_t CC1101::writeCommand(uint8_t command) 
+uint8_t CC1101::writeCommand(uint8_t command)
 {
-	uint8_t result;
-	
-	select();
-	spi_waitMiso();
-	result = SPI.transfer(command);
-	deselect();
-	
-	return result;
+  uint8_t result;
+
+  select();
+  spi_waitMiso();
+  result = SPI.transfer(command);
+  deselect();
+
+  return result;
 }
 
-void CC1101::writeRegister(uint8_t address, uint8_t data) 
+void CC1101::writeRegister(uint8_t address, uint8_t data)
 {
-	select();
-	spi_waitMiso();
-	SPI.transfer(address);
-	SPI.transfer(data);
-	deselect();
+  select();
+  spi_waitMiso();
+  SPI.transfer(address);
+  SPI.transfer(data);
+  deselect();
 }
 
 uint8_t CC1101::readRegister(uint8_t address)
 {
-	uint8_t val;
-  
-	select();
-	spi_waitMiso();
-	SPI.transfer(address);
-	val = SPI.transfer(0);
-	deselect();
-  
-	return val;
+  uint8_t val;
+
+  select();
+  spi_waitMiso();
+  SPI.transfer(address);
+  val = SPI.transfer(0);
+  deselect();
+
+  return val;
 }
 
 uint8_t CC1101::readRegisterMedian3(uint8_t address)
@@ -103,174 +101,188 @@ uint8_t CC1101::readRegisterMedian3(uint8_t address)
   val3 = SPI.transfer(0);
   deselect();
   // reverse sort (largest in val1) because this is te expected order for TX_BUFFER
-  if (val3 > val2) {val = val3; val3 = val2; val2 = val; } //Swap(val3,val2)
-  if (val2 > val1) {val = val2; val2 = val1, val1 = val; } //Swap(val2,val1)
-  if (val3 > val2) {val = val3; val3 = val2, val2 = val; } //Swap(val3,val2)
-  
+  if (val3 > val2) {
+    val = val3;  //Swap(val3,val2)
+    val3 = val2;
+    val2 = val;
+  }
+  if (val2 > val1) {
+    val = val2;  //Swap(val2,val1)
+    val2 = val1, val1 = val;
+  }
+  if (val3 > val2) {
+    val = val3;  //Swap(val3,val2)
+    val3 = val2, val2 = val;
+  }
+
   return val2;
 }
 
 /* Known SPI/26MHz synchronization bug (see CC1101 errata)
-This issue affects the following registers: SPI status byte (fields STATE and FIFO_BYTES_AVAILABLE), 
-FREQEST or RSSI while the receiver is active, MARCSTATE at any time other than an IDLE radio state, 
-RXBYTES when receiving or TXBYTES when transmitting, and WORTIME1/WORTIME0 at any time.*/
+  This issue affects the following registers: SPI status byte (fields STATE and FIFO_BYTES_AVAILABLE),
+  FREQEST or RSSI while the receiver is active, MARCSTATE at any time other than an IDLE radio state,
+  RXBYTES when receiving or TXBYTES when transmitting, and WORTIME1/WORTIME0 at any time.*/
 //uint8_t CC1101::readRegisterWithSyncProblem(uint8_t address, uint8_t registerType)
 uint8_t /* ICACHE_RAM_ATTR */ CC1101::readRegisterWithSyncProblem(uint8_t address, uint8_t registerType)
 {
-	uint8_t value1, value2;	
-	
-	value1 = readRegister(address | registerType);
-	
-	//if two consecutive reads gives us the same result then we know we are ok
-	do 
-	{
-		value2 = value1;
-		value1 = readRegister(address | registerType);
-	} 
-	while (value1 != value2);
-	
-	return value1;
+  uint8_t value1, value2;
+
+  value1 = readRegister(address | registerType);
+
+  //if two consecutive reads gives us the same result then we know we are ok
+  do
+  {
+    value2 = value1;
+    value1 = readRegister(address | registerType);
+  }
+  while (value1 != value2);
+
+  return value1;
 }
 
 //registerType = CC1101_CONFIG_REGISTER or CC1101_STATUS_REGISTER
 uint8_t CC1101::readRegister(uint8_t address, uint8_t registerType)
 {
-	switch (address)
-	{
-		case CC1101_FREQEST:
-		case CC1101_MARCSTATE:
-		case CC1101_RXBYTES:
-		case CC1101_TXBYTES:
-		case CC1101_WORTIME1:
-		case CC1101_WORTIME0:	
-			return readRegisterWithSyncProblem(address, registerType);	
-			
-		default:
-			return readRegister(address | registerType);
-	}
+  switch (address)
+  {
+    case CC1101_FREQEST:
+    case CC1101_MARCSTATE:
+    case CC1101_RXBYTES:
+    case CC1101_TXBYTES:
+    case CC1101_WORTIME1:
+    case CC1101_WORTIME0:
+      return readRegisterWithSyncProblem(address, registerType);
+
+    default:
+      return readRegister(address | registerType);
+  }
 }
 
 void CC1101::writeBurstRegister(uint8_t address, uint8_t* data, uint8_t length)
 {
-	uint8_t i;
+  uint8_t i;
 
-	select();
-	spi_waitMiso();
-	SPI.transfer(address | CC1101_WRITE_BURST);
-	for (i = 0; i < length; i++) {
-		SPI.transfer(data[i]);
-	}
-	deselect();
+  select();
+  spi_waitMiso();
+  SPI.transfer(address | CC1101_WRITE_BURST);
+  for (i = 0; i < length; i++) {
+    SPI.transfer(data[i]);
+  }
+  deselect();
 }
 
 void CC1101::readBurstRegister(uint8_t* buffer, uint8_t address, uint8_t length)
 {
-	uint8_t i;
-	
-	select();
-	spi_waitMiso();
-	SPI.transfer(address | CC1101_READ_BURST);
-	
-	for (i = 0; i < length; i++) {
-		buffer[i] = SPI.transfer(0x00);
-	}
-	
-	deselect();
+  uint8_t i;
+
+  select();
+  spi_waitMiso();
+  SPI.transfer(address | CC1101_READ_BURST);
+
+  for (i = 0; i < length; i++) {
+    buffer[i] = SPI.transfer(0x00);
+  }
+
+  deselect();
 }
 
-//wait for fixed length in rx fifo
-uint8_t CC1101::receiveData(CC1101Packet* packet, uint8_t length)
-{
-	uint8_t rxBytes = readRegisterWithSyncProblem(CC1101_RXBYTES, CC1101_STATUS_REGISTER);
-	rxBytes = rxBytes & CC1101_BITS_RX_BYTES_IN_FIFO;
-	
-	//check for rx fifo overflow
-	if ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER) & CC1101_BITS_MARCSTATE) == CC1101_MARCSTATE_RXFIFO_OVERFLOW)
-	{
-		writeCommand(CC1101_SIDLE);	//idle
-		writeCommand(CC1101_SFRX); //flush RX buffer
-		writeCommand(CC1101_SRX); //switch to RX state	
-	}
-	else if (rxBytes == length)
-	{
-		readBurstRegister(packet->data, CC1101_RXFIFO, rxBytes);
+size_t CC1101::readData(CC1101Packet* packet, size_t maxLen) {
+  size_t length = maxLen;
+  uint8_t bytesInFIFO = 0;
 
-		//continue RX
-		writeCommand(CC1101_SIDLE);	//idle		
-		writeCommand(CC1101_SFRX); //flush RX buffer
-		writeCommand(CC1101_SRX); //switch to RX state	
-		
-		packet->length = rxBytes;				
-	}
-	else
-	{
-		//empty fifo
-		packet->length = 0;
-		writeCommand(CC1101_SIDLE); //idle    
-		writeCommand(CC1101_SFRX); //flush RX buffer
-		writeCommand(CC1101_SRX); //switch to RX state     		
-	}
+  bytesInFIFO = readRegisterWithSyncProblem(CC1101_RXBYTES, CC1101_READ_BURST) & CC1101_BITS_RX_BYTES_IN_FIFO;
 
-	return packet->length;
+  size_t readBytes = 0;
+  uint32_t lastFIFORead = millis();
+
+  // keep reading from FIFO until we get all the packet.
+  while (readBytes < length) {
+    if (bytesInFIFO == 0) {
+      if (millis() - lastFIFORead > 5) {
+        break;
+      } else {
+        bytesInFIFO = readRegisterWithSyncProblem(CC1101_RXBYTES, CC1101_READ_BURST) & CC1101_BITS_RX_BYTES_IN_FIFO;
+        continue;
+      }
+    }
+
+    uint8_t bytesToRead = min((uint8_t)(length - readBytes), bytesInFIFO); // only read from bytesInFIFO if there is buffer length available
+    if (bytesToRead > 1) { //CC1101 errata: RX FIFO pointer is sometimes not properly updated and the last read byte is duplicated, leave on byte in buffer until only one byte is left
+      bytesToRead -= 1;
+    }
+    readBurstRegister(&(packet->data[readBytes]), CC1101_RXFIFO, bytesToRead);
+    readBytes += bytesToRead;
+    packet->length = readBytes;
+    lastFIFORead = millis();
+
+    // Get how many bytes are left in FIFO.
+    bytesInFIFO = readRegisterWithSyncProblem(CC1101_RXBYTES, CC1101_READ_BURST) & CC1101_BITS_RX_BYTES_IN_FIFO;
+  }
+
+  writeCommand(CC1101_SIDLE);  //idle
+  writeCommand(CC1101_SFRX); //flush RX buffer
+  writeCommand(CC1101_SRX); //switch to RX state
+
+  return readBytes;
 }
 
 //This function is able to send packets bigger then the FIFO size.
 void CC1101::sendData(CC1101Packet *packet)
 {
-	uint8_t index = 0;
-	uint8_t txStatus, MarcState;
-	uint8_t length;
-	
-	writeCommand(CC1101_SIDLE);		//idle
+  uint8_t index = 0;
+  uint8_t txStatus, MarcState;
+  uint8_t length;
 
-	txStatus = readRegisterWithSyncProblem(CC1101_TXBYTES, CC1101_STATUS_REGISTER);
-		
-	//clear TX fifo if needed
-	if (txStatus & CC1101_BITS_TX_FIFO_UNDERFLOW)
-	{
-		writeCommand(CC1101_SIDLE);	//idle
-		writeCommand(CC1101_SFTX);	//flush TX buffer
-	}	
-	
-	writeCommand(CC1101_SIDLE);		//idle	
-	
-	//determine how many bytes to send
-	length = (packet->length <= CC1101_DATA_LEN ? packet->length : CC1101_DATA_LEN);
-	
-	writeBurstRegister(CC1101_TXFIFO, packet->data, length);
+  writeCommand(CC1101_SIDLE);		//idle
 
-	writeCommand(CC1101_SIDLE);
-	//start sending packet
-	writeCommand(CC1101_STX);		
+  txStatus = readRegisterWithSyncProblem(CC1101_TXBYTES, CC1101_STATUS_REGISTER);
 
-	//continue sending when packet is bigger than 64 bytes
-	if (packet->length > CC1101_DATA_LEN)
-	{
-		index += length;
-		
-		//loop until all bytes are transmitted
-		while (index < packet->length)
-		{
-			//check if there is free space in the fifo
-			while ((txStatus = (readRegisterMedian3(CC1101_TXBYTES | CC1101_STATUS_REGISTER) & CC1101_BITS_RX_BYTES_IN_FIFO)) > (CC1101_DATA_LEN - 2));
-			
-			//calculate how many bytes we can send
-			length = (CC1101_DATA_LEN - txStatus);
-			length = ((packet->length - index) < length ? (packet->length - index) : length);
-			
-			//send some more bytes
-			for (int i=0; i<length; i++)
-				writeRegister(CC1101_TXFIFO, packet->data[index+i]);
-			
-			index += length;			
-		}
-	}
+  //clear TX fifo if needed
+  if (txStatus & CC1101_BITS_TX_FIFO_UNDERFLOW)
+  {
+    writeCommand(CC1101_SIDLE);	//idle
+    writeCommand(CC1101_SFTX);	//flush TX buffer
+  }
 
-	//wait until transmission is finished (TXOFF_MODE is expected to be set to 0/IDLE or TXFIFO_UNDERFLOW)
-	do
-	{
-		MarcState = (readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER) & CC1101_BITS_MARCSTATE);
-//		if (MarcState == CC1101_MARCSTATE_TXFIFO_UNDERFLOW) Serial.print(F("TXFIFO_UNDERFLOW occured in sendData() \n"));
-	}
-  	while((MarcState != CC1101_MARCSTATE_IDLE) && (MarcState != CC1101_MARCSTATE_TXFIFO_UNDERFLOW));
+  writeCommand(CC1101_SIDLE);		//idle
+
+  //determine how many bytes to send
+  length = (packet->length <= CC1101_DATA_LEN ? packet->length : CC1101_DATA_LEN);
+
+  writeBurstRegister(CC1101_TXFIFO, packet->data, length);
+
+  writeCommand(CC1101_SIDLE);
+  //start sending packet
+  writeCommand(CC1101_STX);
+
+  //continue sending when packet is bigger than 64 bytes
+  if (packet->length > CC1101_DATA_LEN)
+  {
+    index += length;
+
+    //loop until all bytes are transmitted
+    while (index < packet->length)
+    {
+      //check if there is free space in the fifo
+      while ((txStatus = (readRegisterMedian3(CC1101_TXBYTES | CC1101_STATUS_REGISTER) & CC1101_BITS_RX_BYTES_IN_FIFO)) > (CC1101_DATA_LEN - 2));
+
+      //calculate how many bytes we can send
+      length = (CC1101_DATA_LEN - txStatus);
+      length = ((packet->length - index) < length ? (packet->length - index) : length);
+
+      //send some more bytes
+      for (int i = 0; i < length; i++)
+        writeRegister(CC1101_TXFIFO, packet->data[index + i]);
+
+      index += length;
+    }
+  }
+
+  //wait until transmission is finished (TXOFF_MODE is expected to be set to 0/IDLE or TXFIFO_UNDERFLOW)
+  do
+  {
+    MarcState = (readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER) & CC1101_BITS_MARCSTATE);
+    //		if (MarcState == CC1101_MARCSTATE_TXFIFO_UNDERFLOW) Serial.print(F("TXFIFO_UNDERFLOW occured in sendData() \n"));
+  }
+  while ((MarcState != CC1101_MARCSTATE_IDLE) && (MarcState != CC1101_MARCSTATE_TXFIFO_UNDERFLOW));
 }

--- a/Master/Itho/CC1101.cpp
+++ b/Master/Itho/CC1101.cpp
@@ -9,7 +9,7 @@ CC1101::CC1101()
 {
   SPI.begin();
   pinMode(SS, OUTPUT);
-} //CC1101
+} // CC1101
 
 // default destructor
 CC1101::~CC1101()
@@ -18,17 +18,20 @@ CC1101::~CC1101()
 
 /***********************/
 // SPI helper functions select() and deselect()
-inline void CC1101::select(void) {
+inline void CC1101::select(void)
+{
   digitalWrite(SS, LOW);
 }
 
-inline void CC1101::deselect(void) {
+inline void CC1101::deselect(void)
+{
   digitalWrite(SS, HIGH);
 }
 
 void CC1101::spi_waitMiso()
 {
-  while (digitalRead(MISO) == HIGH) yield();
+  while (digitalRead(MISO) == HIGH)
+    yield();
 }
 
 void CC1101::init()
@@ -101,17 +104,20 @@ uint8_t CC1101::readRegisterMedian3(uint8_t address)
   val3 = SPI.transfer(0);
   deselect();
   // reverse sort (largest in val1) because this is te expected order for TX_BUFFER
-  if (val3 > val2) {
-    val = val3;  //Swap(val3,val2)
+  if (val3 > val2)
+  {
+    val = val3; // Swap(val3,val2)
     val3 = val2;
     val2 = val;
   }
-  if (val2 > val1) {
-    val = val2;  //Swap(val2,val1)
+  if (val2 > val1)
+  {
+    val = val2; // Swap(val2,val1)
     val2 = val1, val1 = val;
   }
-  if (val3 > val2) {
-    val = val3;  //Swap(val3,val2)
+  if (val3 > val2)
+  {
+    val = val3; // Swap(val3,val2)
     val3 = val2, val2 = val;
   }
 
@@ -122,56 +128,56 @@ uint8_t CC1101::readRegisterMedian3(uint8_t address)
   This issue affects the following registers: SPI status byte (fields STATE and FIFO_BYTES_AVAILABLE),
   FREQEST or RSSI while the receiver is active, MARCSTATE at any time other than an IDLE radio state,
   RXBYTES when receiving or TXBYTES when transmitting, and WORTIME1/WORTIME0 at any time.*/
-//uint8_t CC1101::readRegisterWithSyncProblem(uint8_t address, uint8_t registerType)
+// uint8_t CC1101::readRegisterWithSyncProblem(uint8_t address, uint8_t registerType)
 uint8_t /* ICACHE_RAM_ATTR */ CC1101::readRegisterWithSyncProblem(uint8_t address, uint8_t registerType)
 {
   uint8_t value1, value2;
 
   value1 = readRegister(address | registerType);
 
-  //if two consecutive reads gives us the same result then we know we are ok
+  // if two consecutive reads gives us the same result then we know we are ok
   do
   {
     value2 = value1;
     value1 = readRegister(address | registerType);
-  }
-  while (value1 != value2);
+  } while (value1 != value2);
 
   return value1;
 }
 
-//registerType = CC1101_CONFIG_REGISTER or CC1101_STATUS_REGISTER
+// registerType = CC1101_CONFIG_REGISTER or CC1101_STATUS_REGISTER
 uint8_t CC1101::readRegister(uint8_t address, uint8_t registerType)
 {
   switch (address)
   {
-    case CC1101_FREQEST:
-    case CC1101_MARCSTATE:
-    case CC1101_RXBYTES:
-    case CC1101_TXBYTES:
-    case CC1101_WORTIME1:
-    case CC1101_WORTIME0:
-      return readRegisterWithSyncProblem(address, registerType);
+  case CC1101_FREQEST:
+  case CC1101_MARCSTATE:
+  case CC1101_RXBYTES:
+  case CC1101_TXBYTES:
+  case CC1101_WORTIME1:
+  case CC1101_WORTIME0:
+    return readRegisterWithSyncProblem(address, registerType);
 
-    default:
-      return readRegister(address | registerType);
+  default:
+    return readRegister(address | registerType);
   }
 }
 
-void CC1101::writeBurstRegister(uint8_t address, uint8_t* data, uint8_t length)
+void CC1101::writeBurstRegister(const uint8_t address, const uint8_t *data, const uint8_t length)
 {
   uint8_t i;
 
   select();
   spi_waitMiso();
   SPI.transfer(address | CC1101_WRITE_BURST);
-  for (i = 0; i < length; i++) {
+  for (i = 0; i < length; i++)
+  {
     SPI.transfer(data[i]);
   }
   deselect();
 }
 
-void CC1101::readBurstRegister(uint8_t* buffer, uint8_t address, uint8_t length)
+void CC1101::readBurstRegister(uint8_t *buffer, const uint8_t address, const uint8_t length)
 {
   uint8_t i;
 
@@ -179,14 +185,16 @@ void CC1101::readBurstRegister(uint8_t* buffer, uint8_t address, uint8_t length)
   spi_waitMiso();
   SPI.transfer(address | CC1101_READ_BURST);
 
-  for (i = 0; i < length; i++) {
+  for (i = 0; i < length; i++)
+  {
     buffer[i] = SPI.transfer(0x00);
   }
 
   deselect();
 }
 
-size_t CC1101::readData(CC1101Packet* packet, size_t maxLen) {
+size_t CC1101::readData(CC1101Packet *packet, size_t maxLen)
+{
   size_t length = maxLen;
   uint8_t bytesInFIFO = 0;
 
@@ -196,18 +204,24 @@ size_t CC1101::readData(CC1101Packet* packet, size_t maxLen) {
   uint32_t lastFIFORead = millis();
 
   // keep reading from FIFO until we get all the packet.
-  while (readBytes < length) {
-    if (bytesInFIFO == 0) {
-      if (millis() - lastFIFORead > 5) {
+  while (readBytes < length)
+  {
+    if (bytesInFIFO == 0)
+    {
+      if (millis() - lastFIFORead > 5)
+      {
         break;
-      } else {
+      }
+      else
+      {
         bytesInFIFO = readRegisterWithSyncProblem(CC1101_RXBYTES, CC1101_READ_BURST) & CC1101_BITS_RX_BYTES_IN_FIFO;
         continue;
       }
     }
 
     uint8_t bytesToRead = min((uint8_t)(length - readBytes), bytesInFIFO); // only read from bytesInFIFO if there is buffer length available
-    if (bytesToRead > 1) { //CC1101 errata: RX FIFO pointer is sometimes not properly updated and the last read byte is duplicated, leave on byte in buffer until only one byte is left
+    if (bytesToRead > 1)
+    { // CC1101 errata: RX FIFO pointer is sometimes not properly updated and the last read byte is duplicated, leave on byte in buffer until only one byte is left
       bytesToRead -= 1;
     }
     readBurstRegister(&(packet->data[readBytes]), CC1101_RXFIFO, bytesToRead);
@@ -219,58 +233,59 @@ size_t CC1101::readData(CC1101Packet* packet, size_t maxLen) {
     bytesInFIFO = readRegisterWithSyncProblem(CC1101_RXBYTES, CC1101_READ_BURST) & CC1101_BITS_RX_BYTES_IN_FIFO;
   }
 
-  writeCommand(CC1101_SIDLE);  //idle
-  writeCommand(CC1101_SFRX); //flush RX buffer
-  writeCommand(CC1101_SRX); //switch to RX state
+  writeCommand(CC1101_SIDLE); // idle
+  writeCommand(CC1101_SFRX);  // flush RX buffer
+  writeCommand(CC1101_SRX);   // switch to RX state
 
   return readBytes;
 }
 
-//This function is able to send packets bigger then the FIFO size.
+// This function is able to send packets bigger then the FIFO size.
 void CC1101::sendData(CC1101Packet *packet)
 {
   uint8_t index = 0;
   uint8_t txStatus, MarcState;
   uint8_t length;
 
-  writeCommand(CC1101_SIDLE);		//idle
+  writeCommand(CC1101_SIDLE); // idle
 
   txStatus = readRegisterWithSyncProblem(CC1101_TXBYTES, CC1101_STATUS_REGISTER);
 
-  //clear TX fifo if needed
+  // clear TX fifo if needed
   if (txStatus & CC1101_BITS_TX_FIFO_UNDERFLOW)
   {
-    writeCommand(CC1101_SIDLE);	//idle
-    writeCommand(CC1101_SFTX);	//flush TX buffer
+    writeCommand(CC1101_SIDLE); // idle
+    writeCommand(CC1101_SFTX);  // flush TX buffer
   }
 
-  writeCommand(CC1101_SIDLE);		//idle
+  writeCommand(CC1101_SIDLE); // idle
 
-  //determine how many bytes to send
+  // determine how many bytes to send
   length = (packet->length <= CC1101_DATA_LEN ? packet->length : CC1101_DATA_LEN);
 
   writeBurstRegister(CC1101_TXFIFO, packet->data, length);
 
   writeCommand(CC1101_SIDLE);
-  //start sending packet
+  // start sending packet
   writeCommand(CC1101_STX);
 
-  //continue sending when packet is bigger than 64 bytes
+  // continue sending when packet is bigger than 64 bytes
   if (packet->length > CC1101_DATA_LEN)
   {
     index += length;
 
-    //loop until all bytes are transmitted
+    // loop until all bytes are transmitted
     while (index < packet->length)
     {
-      //check if there is free space in the fifo
-      while ((txStatus = (readRegisterMedian3(CC1101_TXBYTES | CC1101_STATUS_REGISTER) & CC1101_BITS_RX_BYTES_IN_FIFO)) > (CC1101_DATA_LEN - 2));
+      // check if there is free space in the fifo
+      while ((txStatus = (readRegisterMedian3(CC1101_TXBYTES | CC1101_STATUS_REGISTER) & CC1101_BITS_RX_BYTES_IN_FIFO)) > (CC1101_DATA_LEN - 2))
+        ;
 
-      //calculate how many bytes we can send
+      // calculate how many bytes we can send
       length = (CC1101_DATA_LEN - txStatus);
       length = ((packet->length - index) < length ? (packet->length - index) : length);
 
-      //send some more bytes
+      // send some more bytes
       for (int i = 0; i < length; i++)
         writeRegister(CC1101_TXFIFO, packet->data[index + i]);
 
@@ -278,11 +293,10 @@ void CC1101::sendData(CC1101Packet *packet)
     }
   }
 
-  //wait until transmission is finished (TXOFF_MODE is expected to be set to 0/IDLE or TXFIFO_UNDERFLOW)
+  // wait until transmission is finished (TXOFF_MODE is expected to be set to 0/IDLE or TXFIFO_UNDERFLOW)
   do
   {
     MarcState = (readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER) & CC1101_BITS_MARCSTATE);
-    //		if (MarcState == CC1101_MARCSTATE_TXFIFO_UNDERFLOW) Serial.print(F("TXFIFO_UNDERFLOW occured in sendData() \n"));
-  }
-  while ((MarcState != CC1101_MARCSTATE_IDLE) && (MarcState != CC1101_MARCSTATE_TXFIFO_UNDERFLOW));
+    //		if (MarcState == CC1101_MARCSTATE_TXFIFO_UNDERFLOW) Serial.print("TXFIFO_UNDERFLOW occured in sendData() \n");
+  } while ((MarcState != CC1101_MARCSTATE_IDLE) && (MarcState != CC1101_MARCSTATE_TXFIFO_UNDERFLOW));
 }

--- a/Master/Itho/CC1101.h
+++ b/Master/Itho/CC1101.h
@@ -1,9 +1,8 @@
 /*
  * Author: Klusjesman, modified bij supersjimmie for Arduino/ESP8266
  */
-
-#ifndef __CC1101_H__
-#define __CC1101_H__
+ 
+#pragma once
 
 #include <stdio.h>
 #include "CC1101Packet.h"
@@ -186,7 +185,7 @@ class CC1101
 		void readBurstRegister(uint8_t* buffer, uint8_t address, uint8_t length);
 		
 		void sendData(CC1101Packet *packet);
-		uint8_t receiveData(CC1101Packet* packet, uint8_t length);
+    size_t readData(CC1101Packet* packet, size_t len);
 	
 	private:
 		CC1101( const CC1101 &c );
@@ -203,5 +202,3 @@ class CC1101
 		void reset();
 		
 }; //CC1101
-
-#endif //__CC1101_H__

--- a/Master/Itho/CC1101.h
+++ b/Master/Itho/CC1101.h
@@ -1,204 +1,199 @@
 /*
  * Author: Klusjesman, modified bij supersjimmie for Arduino/ESP8266
  */
- 
+
 #pragma once
 
-#include <stdio.h>
+#include <cstdio>
 #include "CC1101Packet.h"
 #include <SPI.h>
 // On Arduino, SPI pins are predefined
 
 /*	Type of transfers */
-#define CC1101_WRITE_BURST						0x40
-#define CC1101_READ_SINGLE						0x80
-#define CC1101_READ_BURST						0xC0
+#define CC1101_WRITE_BURST 0x40
+#define CC1101_READ_SINGLE 0x80
+#define CC1101_READ_BURST 0xC0
 
 /*	Type of register */
-#define CC1101_CONFIG_REGISTER					CC1101_READ_SINGLE
-#define CC1101_STATUS_REGISTER					CC1101_READ_BURST
+#define CC1101_CONFIG_REGISTER CC1101_READ_SINGLE
+#define CC1101_STATUS_REGISTER CC1101_READ_BURST
 
 /*	PATABLE & FIFO's */
-#define CC1101_PATABLE							0x3E	// PATABLE address
-#define CC1101_TXFIFO							0x3F	// TX FIFO address
-#define CC1101_RXFIFO							0x3F	// RX FIFO address
-#define CC1101_PA_LowPower						0x60
-#define CC1101_PA_LongDistance					0xC0
+#define CC1101_PATABLE 0x3E // PATABLE address
+#define CC1101_TXFIFO 0x3F	// TX FIFO address
+#define CC1101_RXFIFO 0x3F	// RX FIFO address
+#define CC1101_PA_LowPower 0x60
+#define CC1101_PA_LongDistance 0xC0
 
 /*	Command strobes */
-#define CC1101_SRES								0x30	// Reset CC1101 chip
-#define CC1101_SFSTXON							0x31	// Enable and calibrate frequency synthesizer (if MCSM0.FS_AUTOCAL=1). If in RX (with CCA): Go to a wait state where only the synthesizer is running (for quick RX / TX turnaround).
-#define CC1101_SXOFF							0x32	// Turn off crystal oscillator
-#define CC1101_SCAL								0x33	// Calibrate frequency synthesizer and turn it off. SCAL can be strobed from IDLE mode without setting manual calibration mode (MCSM0.FS_AUTOCAL=0)
-#define CC1101_SRX								0x34	// Enable RX. Perform calibration first if coming from IDLE and MCSM0.FS_AUTOCAL=1
-#define CC1101_STX								0x35	// In IDLE state: Enable TX. Perform calibration first if MCSM0.FS_AUTOCAL=1. If in RX state and CCA is enabled: Only go to TX if channel is clear
-#define CC1101_SIDLE							0x36	// Exit RX / TX, turn off frequency synthesizer and exit Wake-On-Radio mode if applicable
-#define CC1101_SWOR								0x38	// Start automatic RX polling sequence (Wake-on-Radio) as described in Section 19.5 if WORCTRL.RC_PD=0
-#define CC1101_SPWD								0x39	// Enter power down mode when CSn goes high
-#define CC1101_SFRX								0x3A	// Flush the RX FIFO buffer. Only issue SFRX in IDLE or RXFIFO_OVERFLOW states
-#define CC1101_SFTX								0x3B	// Flush the TX FIFO buffer. Only issue SFTX in IDLE or TXFIFO_UNDERFLOW states
-#define CC1101_SWORRST							0x3C	// Reset real time clock to Event1 value
-#define CC1101_SNOP								0x3D	// No operation. May be used to get access to the chip status byte
+#define CC1101_SRES 0x30	// Reset CC1101 chip
+#define CC1101_SFSTXON 0x31 // Enable and calibrate frequency synthesizer (if MCSM0.FS_AUTOCAL=1). If in RX (with CCA): Go to a wait state where only the synthesizer is running (for quick RX / TX turnaround).
+#define CC1101_SXOFF 0x32	// Turn off crystal oscillator
+#define CC1101_SCAL 0x33	// Calibrate frequency synthesizer and turn it off. SCAL can be strobed from IDLE mode without setting manual calibration mode (MCSM0.FS_AUTOCAL=0)
+#define CC1101_SRX 0x34		// Enable RX. Perform calibration first if coming from IDLE and MCSM0.FS_AUTOCAL=1
+#define CC1101_STX 0x35		// In IDLE state: Enable TX. Perform calibration first if MCSM0.FS_AUTOCAL=1. If in RX state and CCA is enabled: Only go to TX if channel is clear
+#define CC1101_SIDLE 0x36	// Exit RX / TX, turn off frequency synthesizer and exit Wake-On-Radio mode if applicable
+#define CC1101_SWOR 0x38	// Start automatic RX polling sequence (Wake-on-Radio) as described in Section 19.5 if WORCTRL.RC_PD=0
+#define CC1101_SPWD 0x39	// Enter power down mode when CSn goes high
+#define CC1101_SFRX 0x3A	// Flush the RX FIFO buffer. Only issue SFRX in IDLE or RXFIFO_OVERFLOW states
+#define CC1101_SFTX 0x3B	// Flush the TX FIFO buffer. Only issue SFTX in IDLE or TXFIFO_UNDERFLOW states
+#define CC1101_SWORRST 0x3C // Reset real time clock to Event1 value
+#define CC1101_SNOP 0x3D	// No operation. May be used to get access to the chip status byte
 
 /*	CC1101 configuration registers */
-#define CC1101_IOCFG2							0x00	// GDO2 Output Pin Configuration
-#define CC1101_IOCFG1							0x01	// GDO1 Output Pin Configuration
-#define CC1101_IOCFG0							0x02	// GDO0 Output Pin Configuration
-#define CC1101_FIFOTHR							0x03	// RX FIFO and TX FIFO Thresholds
-#define CC1101_SYNC1							0x04	// Sync Word, High Byte
-#define CC1101_SYNC0							0x05	// Sync Word, Low Byte
-#define CC1101_PKTLEN							0x06	// Packet Length
-#define CC1101_PKTCTRL1							0x07	// Packet Automation Control
-#define CC1101_PKTCTRL0							0x08	// Packet Automation Control
-#define CC1101_ADDR								0x09	// Device Address
-#define CC1101_CHANNR							0x0A	// Channel Number
-#define CC1101_FSCTRL1							0x0B	// Frequency Synthesizer Control
-#define CC1101_FSCTRL0							0x0C	// Frequency Synthesizer Control
-#define CC1101_FREQ2							0x0D	// Frequency Control Word, High Byte
-#define CC1101_FREQ1							0x0E	// Frequency Control Word, Middle Byte
-#define CC1101_FREQ0							0x0F	// Frequency Control Word, Low Byte
-#define CC1101_MDMCFG4							0x10	// Modem Configuration
-#define CC1101_MDMCFG3							0x11	// Modem Configuration
-#define CC1101_MDMCFG2							0x12	// Modem Configuration
-#define CC1101_MDMCFG1							0x13	// Modem Configuration
-#define CC1101_MDMCFG0							0x14	// Modem Configuration
-#define CC1101_DEVIATN							0x15	// Modem Deviation Setting
-#define CC1101_MCSM2							0x16	// Main Radio Control State Machine Configuration
-#define CC1101_MCSM1							0x17	// Main Radio Control State Machine Configuration
-#define CC1101_MCSM0							0x18	// Main Radio Control State Machine Configuration
-#define CC1101_FOCCFG							0x19	// Frequency Offset Compensation Configuration
-#define CC1101_BSCFG							0x1A	// Bit Synchronization Configuration
-#define CC1101_AGCCTRL2							0x1B	// AGC Control
-#define CC1101_AGCCTRL1							0x1C	// AGC Control
-#define CC1101_AGCCTRL0							0x1D	// AGC Control
-#define CC1101_WOREVT1							0x1E	// High Byte Event0 Timeout
-#define CC1101_WOREVT0							0x1F	// Low Byte Event0 Timeout
-#define CC1101_WORCTRL							0x20	// Wake On Radio Control
-#define CC1101_FREND1							0x21	// Front End RX Configuration
-#define CC1101_FREND0							0x22	// Front End TX Configuration
-#define CC1101_FSCAL3							0x23	// Frequency Synthesizer Calibration
-#define CC1101_FSCAL2							0x24	// Frequency Synthesizer Calibration
-#define CC1101_FSCAL1							0x25	// Frequency Synthesizer Calibration
-#define CC1101_FSCAL0							0x26	// Frequency Synthesizer Calibration
-#define CC1101_RCCTRL1							0x27	// RC Oscillator Configuration
-#define CC1101_RCCTRL0							0x28	// RC Oscillator Configuration
-#define CC1101_FSTEST							0x29	// Frequency Synthesizer Calibration Control
-#define CC1101_PTEST							0x2A	// Production Test
-#define CC1101_AGCTEST							0x2B	// AGC Test
-#define CC1101_TEST2							0x2C	// Various Test Settings
-#define CC1101_TEST1							0x2D	// Various Test Settings
-#define CC1101_TEST0							0x2E	// Various Test Settings
+#define CC1101_IOCFG2 0x00	 // GDO2 Output Pin Configuration
+#define CC1101_IOCFG1 0x01	 // GDO1 Output Pin Configuration
+#define CC1101_IOCFG0 0x02	 // GDO0 Output Pin Configuration
+#define CC1101_FIFOTHR 0x03	 // RX FIFO and TX FIFO Thresholds
+#define CC1101_SYNC1 0x04	 // Sync Word, High Byte
+#define CC1101_SYNC0 0x05	 // Sync Word, Low Byte
+#define CC1101_PKTLEN 0x06	 // Packet Length
+#define CC1101_PKTCTRL1 0x07 // Packet Automation Control
+#define CC1101_PKTCTRL0 0x08 // Packet Automation Control
+#define CC1101_ADDR 0x09	 // Device Address
+#define CC1101_CHANNR 0x0A	 // Channel Number
+#define CC1101_FSCTRL1 0x0B	 // Frequency Synthesizer Control
+#define CC1101_FSCTRL0 0x0C	 // Frequency Synthesizer Control
+#define CC1101_FREQ2 0x0D	 // Frequency Control Word, High Byte
+#define CC1101_FREQ1 0x0E	 // Frequency Control Word, Middle Byte
+#define CC1101_FREQ0 0x0F	 // Frequency Control Word, Low Byte
+#define CC1101_MDMCFG4 0x10	 // Modem Configuration
+#define CC1101_MDMCFG3 0x11	 // Modem Configuration
+#define CC1101_MDMCFG2 0x12	 // Modem Configuration
+#define CC1101_MDMCFG1 0x13	 // Modem Configuration
+#define CC1101_MDMCFG0 0x14	 // Modem Configuration
+#define CC1101_DEVIATN 0x15	 // Modem Deviation Setting
+#define CC1101_MCSM2 0x16	 // Main Radio Control State Machine Configuration
+#define CC1101_MCSM1 0x17	 // Main Radio Control State Machine Configuration
+#define CC1101_MCSM0 0x18	 // Main Radio Control State Machine Configuration
+#define CC1101_FOCCFG 0x19	 // Frequency Offset Compensation Configuration
+#define CC1101_BSCFG 0x1A	 // Bit Synchronization Configuration
+#define CC1101_AGCCTRL2 0x1B // AGC Control
+#define CC1101_AGCCTRL1 0x1C // AGC Control
+#define CC1101_AGCCTRL0 0x1D // AGC Control
+#define CC1101_WOREVT1 0x1E	 // High Byte Event0 Timeout
+#define CC1101_WOREVT0 0x1F	 // Low Byte Event0 Timeout
+#define CC1101_WORCTRL 0x20	 // Wake On Radio Control
+#define CC1101_FREND1 0x21	 // Front End RX Configuration
+#define CC1101_FREND0 0x22	 // Front End TX Configuration
+#define CC1101_FSCAL3 0x23	 // Frequency Synthesizer Calibration
+#define CC1101_FSCAL2 0x24	 // Frequency Synthesizer Calibration
+#define CC1101_FSCAL1 0x25	 // Frequency Synthesizer Calibration
+#define CC1101_FSCAL0 0x26	 // Frequency Synthesizer Calibration
+#define CC1101_RCCTRL1 0x27	 // RC Oscillator Configuration
+#define CC1101_RCCTRL0 0x28	 // RC Oscillator Configuration
+#define CC1101_FSTEST 0x29	 // Frequency Synthesizer Calibration Control
+#define CC1101_PTEST 0x2A	 // Production Test
+#define CC1101_AGCTEST 0x2B	 // AGC Test
+#define CC1101_TEST2 0x2C	 // Various Test Settings
+#define CC1101_TEST1 0x2D	 // Various Test Settings
+#define CC1101_TEST0 0x2E	 // Various Test Settings
 
 /*	Status registers */
-#define CC1101_PARTNUM							0x30	// Chip ID
-#define CC1101_VERSION							0x31	// Chip ID
-#define CC1101_FREQEST							0x32	// Frequency Offset Estimate from Demodulator
-#define CC1101_LQI								0x33	// Demodulator Estimate for Link Quality
-#define CC1101_RSSI								0x34	// Received Signal Strength Indication
-#define CC1101_MARCSTATE						0x35	// Main Radio Control State Machine State
-#define CC1101_WORTIME1							0x36	// High Byte of WOR Time
-#define CC1101_WORTIME0							0x37	// Low Byte of WOR Time
-#define CC1101_PKTSTATUS						0x38	// Current GDOx Status and Packet Status
-#define CC1101_VCO_VC_DAC						0x39	// Current Setting from PLL Calibration Module
-#define CC1101_TXBYTES							0x3A	// Underflow and Number of Bytes
-#define CC1101_RXBYTES							0x3B	// Overflow and Number of Bytes
-#define CC1101_RCCTRL1_STATUS					0x3C	// Last RC Oscillator Calibration Result
-#define CC1101_RCCTRL0_STATUS					0x3D	// Last RC Oscillator Calibration Result
+#define CC1101_PARTNUM 0x30		   // Chip ID
+#define CC1101_VERSION 0x31		   // Chip ID
+#define CC1101_FREQEST 0x32		   // Frequency Offset Estimate from Demodulator
+#define CC1101_LQI 0x33			   // Demodulator Estimate for Link Quality
+#define CC1101_RSSI 0x34		   // Received Signal Strength Indication
+#define CC1101_MARCSTATE 0x35	   // Main Radio Control State Machine State
+#define CC1101_WORTIME1 0x36	   // High Byte of WOR Time
+#define CC1101_WORTIME0 0x37	   // Low Byte of WOR Time
+#define CC1101_PKTSTATUS 0x38	   // Current GDOx Status and Packet Status
+#define CC1101_VCO_VC_DAC 0x39	   // Current Setting from PLL Calibration Module
+#define CC1101_TXBYTES 0x3A		   // Underflow and Number of Bytes
+#define CC1101_RXBYTES 0x3B		   // Overflow and Number of Bytes
+#define CC1101_RCCTRL1_STATUS 0x3C // Last RC Oscillator Calibration Result
+#define CC1101_RCCTRL0_STATUS 0x3D // Last RC Oscillator Calibration Result
 
 /* Bit fields in the chip status byte */
-#define CC1101_STATUS_CHIP_RDYn_BM              0x80
-#define CC1101_STATUS_STATE_BM                  0x70
-#define CC1101_STATUS_FIFO_BYTES_AVAILABLE_BM   0x0F
+#define CC1101_STATUS_CHIP_RDYn_BM 0x80
+#define CC1101_STATUS_STATE_BM 0x70
+#define CC1101_STATUS_FIFO_BYTES_AVAILABLE_BM 0x0F
 
 /* Masks to retrieve status bit */
-#define CC1101_BITS_TX_FIFO_UNDERFLOW			0x80
-#define CC1101_BITS_RX_BYTES_IN_FIFO			0x7F
-#define CC1101_BITS_MARCSTATE					0x1F
-
+#define CC1101_BITS_TX_FIFO_UNDERFLOW 0x80
+#define CC1101_BITS_RX_BYTES_IN_FIFO 0x7F
+#define CC1101_BITS_MARCSTATE 0x1F
 
 /* Marc states */
 enum CC1101MarcStates
 {
-	CC1101_MARCSTATE_SLEEP					= 0x00,
-	CC1101_MARCSTATE_IDLE					= 0x01,
-	CC1101_MARCSTATE_XOFF					= 0x02,
-	CC1101_MARCSTATE_VCOON_MC				= 0x03,
-	CC1101_MARCSTATE_REGON_MC				= 0x04,
-	CC1101_MARCSTATE_MANCAL					= 0x05,
-	CC1101_MARCSTATE_VCOON					= 0x06,
-	CC1101_MARCSTATE_REGON					= 0x07,
-	CC1101_MARCSTATE_STARTCAL				= 0x08,
-	CC1101_MARCSTATE_BWBOOST				= 0x09,
-	CC1101_MARCSTATE_FS_LOCK				= 0x0A,
-	CC1101_MARCSTATE_IFADCON				= 0x0B,
-	CC1101_MARCSTATE_ENDCAL					= 0x0C,
-	CC1101_MARCSTATE_RX						= 0x0D,
-	CC1101_MARCSTATE_RX_END					= 0x0E,
-	CC1101_MARCSTATE_RX_RST					= 0x0F,
-	CC1101_MARCSTATE_TXRX_SWITCH			= 0x10,
-	CC1101_MARCSTATE_RXFIFO_OVERFLOW		= 0x11,
-	CC1101_MARCSTATE_FSTXON					= 0x12,
-	CC1101_MARCSTATE_TX						= 0x13,
-	CC1101_MARCSTATE_TX_END					= 0x14,
-	CC1101_MARCSTATE_RXTX_SWITCH			= 0x15,
-	CC1101_MARCSTATE_TXFIFO_UNDERFLOW		= 0x16
+	CC1101_MARCSTATE_SLEEP = 0x00,
+	CC1101_MARCSTATE_IDLE = 0x01,
+	CC1101_MARCSTATE_XOFF = 0x02,
+	CC1101_MARCSTATE_VCOON_MC = 0x03,
+	CC1101_MARCSTATE_REGON_MC = 0x04,
+	CC1101_MARCSTATE_MANCAL = 0x05,
+	CC1101_MARCSTATE_VCOON = 0x06,
+	CC1101_MARCSTATE_REGON = 0x07,
+	CC1101_MARCSTATE_STARTCAL = 0x08,
+	CC1101_MARCSTATE_BWBOOST = 0x09,
+	CC1101_MARCSTATE_FS_LOCK = 0x0A,
+	CC1101_MARCSTATE_IFADCON = 0x0B,
+	CC1101_MARCSTATE_ENDCAL = 0x0C,
+	CC1101_MARCSTATE_RX = 0x0D,
+	CC1101_MARCSTATE_RX_END = 0x0E,
+	CC1101_MARCSTATE_RX_RST = 0x0F,
+	CC1101_MARCSTATE_TXRX_SWITCH = 0x10,
+	CC1101_MARCSTATE_RXFIFO_OVERFLOW = 0x11,
+	CC1101_MARCSTATE_FSTXON = 0x12,
+	CC1101_MARCSTATE_TX = 0x13,
+	CC1101_MARCSTATE_TX_END = 0x14,
+	CC1101_MARCSTATE_RXTX_SWITCH = 0x15,
+	CC1101_MARCSTATE_TXFIFO_UNDERFLOW = 0x16
 };
-
 
 /* Chip states */
 enum CC1101ChipStates
 {
-	CC1101_STATE_MASK                       = 0x70,
-	CC1101_STATE_IDLE                       = 0x00,
-	CC1101_STATE_RX                         = 0x10,
-	CC1101_STATE_TX                         = 0x20,
-	CC1101_STATE_FSTXON                     = 0x30,
-	CC1101_STATE_CALIBRATE                  = 0x40,
-	CC1101_STATE_SETTLING                   = 0x50,
-	CC1101_STATE_RX_OVERFLOW                = 0x60,
-	CC1101_STATE_TX_UNDERFLOW               = 0x70	
+	CC1101_STATE_MASK = 0x70,
+	CC1101_STATE_IDLE = 0x00,
+	CC1101_STATE_RX = 0x10,
+	CC1101_STATE_TX = 0x20,
+	CC1101_STATE_FSTXON = 0x30,
+	CC1101_STATE_CALIBRATE = 0x40,
+	CC1101_STATE_SETTLING = 0x50,
+	CC1101_STATE_RX_OVERFLOW = 0x60,
+	CC1101_STATE_TX_UNDERFLOW = 0x70
 };
-
-
 
 class CC1101
 {
-	protected:
-		
-	//functions
-	public:
-		CC1101();
-		~CC1101();
-	
-		//spi
-		void spi_waitMiso();
-	
-		//cc1101
-		void init();
-		
-		uint8_t writeCommand(uint8_t command);
-		void writeRegister(uint8_t address, uint8_t data);
-		
-		uint8_t readRegister(uint8_t address, uint8_t registerType);
-				
-		void writeBurstRegister(uint8_t address, uint8_t* data, uint8_t length);
-		void readBurstRegister(uint8_t* buffer, uint8_t address, uint8_t length);
-		
-		void sendData(CC1101Packet *packet);
-    size_t readData(CC1101Packet* packet, size_t len);
-	
-	private:
-		CC1101( const CC1101 &c );
-		CC1101& operator=( const CC1101 &c );
-		// SPI helper functions
-		void select(void);
-		void deselect(void);
-		
-	protected:
-		uint8_t readRegister(uint8_t address);
-		uint8_t readRegisterMedian3(uint8_t address);
-		uint8_t readRegisterWithSyncProblem(uint8_t address, uint8_t registerType);
-		
-		void reset();
-		
-}; //CC1101
+protected:
+	// functions
+public:
+	CC1101();
+	~CC1101();
+
+	// spi
+	void spi_waitMiso();
+
+	// cc1101
+	void init();
+
+	uint8_t writeCommand(uint8_t command);
+	void writeRegister(uint8_t address, uint8_t data);
+
+	uint8_t readRegister(uint8_t address, uint8_t registerType);
+
+	void writeBurstRegister(const uint8_t address, const uint8_t *data, const uint8_t length);
+	void readBurstRegister(uint8_t *buffer, const uint8_t address, const uint8_t length);
+
+	void sendData(CC1101Packet *packet);
+	size_t readData(CC1101Packet *packet, size_t len);
+
+private:
+	CC1101(const CC1101 &c);
+	CC1101 &operator=(const CC1101 &c);
+	// SPI helper functions
+	void select(void);
+	void deselect(void);
+
+protected:
+	uint8_t readRegister(uint8_t address);
+	uint8_t readRegisterMedian3(uint8_t address);
+	uint8_t readRegisterWithSyncProblem(uint8_t address, uint8_t registerType);
+
+	void reset();
+
+}; // CC1101

--- a/Master/Itho/CC1101Packet.h
+++ b/Master/Itho/CC1101Packet.h
@@ -6,7 +6,7 @@
 #define CC1101PACKET_H_
 
 #include <stdio.h>
-#include <arduino.h>
+#include <Arduino.h>
 
 #define CC1101_BUFFER_LEN        64
 #define CC1101_DATA_LEN          CC1101_BUFFER_LEN - 3

--- a/Master/Itho/CC1101Packet.h
+++ b/Master/Itho/CC1101Packet.h
@@ -2,22 +2,18 @@
  * Author: Klusjesman, modified bij supersjimmie for Arduino/ESP8266
  */
 
-#ifndef CC1101PACKET_H_
-#define CC1101PACKET_H_
+#pragma once
 
 #include <stdio.h>
 #include <Arduino.h>
 
 #define CC1101_BUFFER_LEN        64
 #define CC1101_DATA_LEN          CC1101_BUFFER_LEN - 3
-
+#define MAX_RAW                  162
 
 class CC1101Packet
 {
 	public:
 		uint8_t length;
-		uint8_t data[128];
+		uint8_t data[MAX_RAW];
 };
-
-
-#endif /* CC1101PACKET_H_ */

--- a/Master/Itho/CC1101Packet.h
+++ b/Master/Itho/CC1101Packet.h
@@ -6,9 +6,7 @@
 #define CC1101PACKET_H_
 
 #include <stdio.h>
-#ifdef ESP8266
 #include <arduino.h>
-#endif
 
 #define CC1101_BUFFER_LEN        64
 #define CC1101_DATA_LEN          CC1101_BUFFER_LEN - 3
@@ -18,7 +16,7 @@ class CC1101Packet
 {
 	public:
 		uint8_t length;
-		uint8_t data[72];
+		uint8_t data[128];
 };
 
 

--- a/Master/Itho/CC1101Packet.h
+++ b/Master/Itho/CC1101Packet.h
@@ -4,16 +4,16 @@
 
 #pragma once
 
-#include <stdio.h>
+#include <cstdio>
 #include <Arduino.h>
 
-#define CC1101_BUFFER_LEN        64
-#define CC1101_DATA_LEN          CC1101_BUFFER_LEN - 3
-#define MAX_RAW                  162
+#define CC1101_BUFFER_LEN 64
+#define CC1101_DATA_LEN CC1101_BUFFER_LEN - 3
+#define MAX_RAW 162
 
 class CC1101Packet
 {
-	public:
-		uint8_t length;
-		uint8_t data[MAX_RAW];
+public:
+	uint8_t length = 0;
+	uint8_t data[MAX_RAW]{};
 };

--- a/Master/Itho/IthoCC1101.cpp
+++ b/Master/Itho/IthoCC1101.cpp
@@ -19,6 +19,8 @@
 #include <Arduino.h>
 #include <SPI.h>
 
+//#define CRC_FILTER
+
 ////original sync byte pattern
 //#define STARTBYTE 6 //relevant data starts 6 bytes after the sync pattern bytes 170/171
 //#define SYNC1 170
@@ -351,7 +353,7 @@ bool IthoCC1101::parseMessageCommand() {
   if (isRVJoinCommand)   inIthoPacket.command = IthoJoin;
   if (isLeaveCommand)    inIthoPacket.command = IthoLeave;
   
-
+#if defined (CRC_FILTER)
   uint8_t mLen = 0;
   if (isPowerCommand || isHighCommand || isMediumCommand || isLowCommand || isStandByCommand || isTimer1Command || isTimer2Command || isTimer3Command) {
     mLen = 11;
@@ -369,7 +371,8 @@ bool IthoCC1101::parseMessageCommand() {
     inIthoPacket.command = IthoUnknown;
     return false;
   }
-  
+#endif
+
   return true;
 }
 

--- a/Master/Itho/IthoCC1101.cpp
+++ b/Master/Itho/IthoCC1101.cpp
@@ -1,6 +1,18 @@
 /*
- * Author: Klusjesman, modified bij supersjimmie for Arduino/ESP8266
- */
+   Author: Klusjesman, supersjimmie, modified and reworked by arjenhiemstra
+*/
+#define DEBUG 0
+
+#define BYTE_TO_BINARY_PATTERN "%c,%c,%c,%c,%c,%c,%c,%c,"
+#define BYTE_TO_BINARY(byte)  \
+  (byte & 0x80 ? '1' : '0'), \
+  (byte & 0x40 ? '1' : '0'), \
+  (byte & 0x20 ? '1' : '0'), \
+  (byte & 0x10 ? '1' : '0'), \
+  (byte & 0x08 ? '1' : '0'), \
+  (byte & 0x04 ? '1' : '0'), \
+  (byte & 0x02 ? '1' : '0'), \
+  (byte & 0x01 ? '1' : '0')
 
 #include "IthoCC1101.h"
 #include <string.h>
@@ -10,45 +22,15 @@
 // default constructor
 IthoCC1101::IthoCC1101(uint8_t counter, uint8_t sendTries) : CC1101()
 {
-	this->outIthoPacket.counter = counter;
-	this->outIthoPacket.previous = IthoLow;
-	this->sendTries = sendTries;
-//	this->receiveState = ExpectNormalCommand;
-	this->receiveState = ExpectMessageStart;
-	
-////fixed device id - duco remote with standby
-	//this->outIthoPacket.deviceId1[0] = 83;
-	//this->outIthoPacket.deviceId1[1] = 45;
-	//this->outIthoPacket.deviceId1[2] = 77;
-	//this->outIthoPacket.deviceId1[3] = 75;
-	//this->outIthoPacket.deviceId1[4] = 51;
-	//this->outIthoPacket.deviceId1[5] = 76;
-	////
-	//this->outIthoPacket.deviceId2[0] = 105;
-	//this->outIthoPacket.deviceId2[1] = 153;
-	//this->outIthoPacket.deviceId2[2] = 150;
-	//this->outIthoPacket.deviceId2[3] = 101;
-	//this->outIthoPacket.deviceId2[4] = 169;
-	//this->outIthoPacket.deviceId2[5] = 105;
-	//this->outIthoPacket.deviceId2[6] = 89;
-	//this->outIthoPacket.deviceId2[7] = 166;
+  this->outIthoPacket.counter = counter;
+  this->sendTries = sendTries;
 
-	//fixed device id - rft remote with timer
-	this->outIthoPacket.deviceId1[0] = 51;
-	this->outIthoPacket.deviceId1[1] = 83;
-	this->outIthoPacket.deviceId1[2] = 51;
-	this->outIthoPacket.deviceId1[3] = 43;
-	this->outIthoPacket.deviceId1[4] = 84;
-	this->outIthoPacket.deviceId1[5] = 204;
-	//
-	this->outIthoPacket.deviceId2[0] = 101;
-	this->outIthoPacket.deviceId2[1] = 89;
-	this->outIthoPacket.deviceId2[2] = 154;
-	this->outIthoPacket.deviceId2[3] = 153;
-	this->outIthoPacket.deviceId2[4] = 170;
-	this->outIthoPacket.deviceId2[5] = 105;
-	this->outIthoPacket.deviceId2[6] = 154;
-	this->outIthoPacket.deviceId2[7] = 86;
+  this->outIthoPacket.deviceId[0] = 33;
+  this->outIthoPacket.deviceId[1] = 66;
+  this->outIthoPacket.deviceId[2] = 99;
+
+  this->outIthoPacket.deviceType = 22;
+
 } //IthoCC1101
 
 // default destructor
@@ -56,901 +38,712 @@ IthoCC1101::~IthoCC1101()
 {
 } //~IthoCC1101
 
-void IthoCC1101::initSendMessage1()
+void IthoCC1101::initSendMessage(uint8_t len)
 {
-	/*
-	Configuration reverse engineered from remote print. The commands below are used by IthoDaalderop.
-		
-	Base frequency		868.299866MHz
-	Channel				0
-	Channel spacing		199.951172kHz
-	Carrier frequency	868.299866MHz
-	Xtal frequency		26.000000MHz
-	Data rate			8.00896kBaud
-	Manchester			disabled
-	Modulation			2-FSK
-	Deviation			25.390625kHz
-	TX power			?
-	PA ramping			enabled
-	Whitening			disabled
-	*/
-	writeCommand(CC1101_SRES);
-	delayMicroseconds(1);
-	writeRegister(CC1101_IOCFG0 ,0x2E);		//High impedance (3-state)
-	writeRegister(CC1101_FREQ2 ,0x21);		//00100001	878MHz-927.8MHz
-	writeRegister(CC1101_FREQ1 ,0x65);		//01100101
-	writeRegister(CC1101_FREQ0 ,0x6A);		//01101010
-	writeRegister(CC1101_MDMCFG4 ,0x07);	//00000111
-	writeRegister(CC1101_MDMCFG3 ,0x43);	//01000011
-	writeRegister(CC1101_MDMCFG2 ,0x00);	//00000000	2-FSK, no manchester encoding/decoding, no preamble/sync
-	writeRegister(CC1101_MDMCFG1 ,0x22);	//00100010
-	writeRegister(CC1101_MDMCFG0 ,0xF8);	//11111000
-	writeRegister(CC1101_CHANNR ,0x00);		//00000000
-	writeRegister(CC1101_DEVIATN ,0x40);	//01000000
-	writeRegister(CC1101_FREND0 ,0x17);		//00010111	use index 7 in PA table
-	writeRegister(CC1101_MCSM0 ,0x18);		//00011000	PO timeout Approx. 146µs - 171µs, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
-	writeRegister(CC1101_FSCAL3 ,0xA9);		//10101001
-	writeRegister(CC1101_FSCAL2 ,0x2A);		//00101010
-	writeRegister(CC1101_FSCAL1 ,0x00);		//00000000
-	writeRegister(CC1101_FSCAL0 ,0x11);		//00010001
-	writeRegister(CC1101_FSTEST ,0x59);		//01011001	For test only. Do not write to this register.
-	writeRegister(CC1101_TEST2 ,0x81);		//10000001	For test only. Do not write to this register.
-	writeRegister(CC1101_TEST1 ,0x35);		//00110101	For test only. Do not write to this register.
-	writeRegister(CC1101_TEST0 ,0x0B);		//00001011	For test only. Do not write to this register.
-	writeRegister(CC1101_PKTCTRL0 ,0x12);	//00010010	Enable infinite length packets, CRC disabled, Turn data whitening off, Serial Synchronous mode
-	writeRegister(CC1101_ADDR ,0x00);		//00000000
-	writeRegister(CC1101_PKTLEN ,0xFF);		//11111111	//Not used, no hardware packet handling
+  //finishTransfer();
+  writeCommand(CC1101_SIDLE);
+  delayMicroseconds(1);
+  writeRegister(CC1101_IOCFG0 , 0x2E);
+  delayMicroseconds(1);
+  writeRegister(CC1101_IOCFG1 , 0x2E);
+  delayMicroseconds(1);
+  writeCommand(CC1101_SIDLE);
+  writeCommand(CC1101_SPWD);
+  delayMicroseconds(2);
 
-	//0x6F,0x26,0x2E,0x8C,0x87,0xCD,0xC7,0xC0
-	writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, (uint8_t*)ithoPaTableSend, 8);
+  /*
+    Configuration reverse engineered from remote print. The commands below are used by IthoDaalderop.
 
-	writeCommand(CC1101_SIDLE);
-	writeCommand(CC1101_SIDLE);
-	writeCommand(CC1101_SIDLE);
+    Base frequency		868.299866MHz
+    Channel				0
+    Channel spacing		199.951172kHz
+    Carrier frequency	868.299866MHz
+    Xtal frequency		26.000000MHz
+    Data rate			38.3835kBaud
+    Manchester			disabled
+    Modulation			2-FSK
+    Deviation			50.781250kHz
+    TX power			?
+    PA ramping			enabled
+    Whitening			disabled
+  */
+  writeCommand(CC1101_SRES);
+  delayMicroseconds(1);
+  writeRegister(CC1101_IOCFG0 , 0x2E);		//High impedance (3-state)
+  writeRegister(CC1101_FREQ2 , 0x21);		//00100001	878MHz-927.8MHz
+  writeRegister(CC1101_FREQ1 , 0x65);		//01100101
+  writeRegister(CC1101_FREQ0 , 0x6A);		//01101010
+  writeRegister(CC1101_MDMCFG4 , 0x5A);	//difference compared to message1
+  writeRegister(CC1101_MDMCFG3 , 0x83);	//difference compared to message1
+  writeRegister(CC1101_MDMCFG2 , 0x00);	//00000000	2-FSK, no manchester encoding/decoding, no preamble/sync
+  writeRegister(CC1101_MDMCFG1 , 0x22);	//00100010
+  writeRegister(CC1101_MDMCFG0 , 0xF8);	//11111000
+  writeRegister(CC1101_CHANNR , 0x00);		//00000000
+  writeRegister(CC1101_DEVIATN , 0x50);	//difference compared to message1
+  writeRegister(CC1101_FREND0 , 0x17);		//00010111	use index 7 in PA table
+  writeRegister(CC1101_MCSM0 , 0x18);		//00011000	PO timeout Approx. 146ï¿½s - 171ï¿½s, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
+  writeRegister(CC1101_FSCAL3 , 0xA9);		//10101001
+  writeRegister(CC1101_FSCAL2 , 0x2A);		//00101010
+  writeRegister(CC1101_FSCAL1 , 0x00);		//00000000
+  writeRegister(CC1101_FSCAL0 , 0x11);		//00010001
+  writeRegister(CC1101_FSTEST , 0x59);		//01011001	For test only. Do not write to this register.
+  writeRegister(CC1101_TEST2 , 0x81);		//10000001	For test only. Do not write to this register.
+  writeRegister(CC1101_TEST1 , 0x35);		//00110101	For test only. Do not write to this register.
+  writeRegister(CC1101_TEST0 , 0x0B);		//00001011	For test only. Do not write to this register.
+  writeRegister(CC1101_PKTCTRL0 , 0x12);	//00010010	Enable infinite length packets, CRC disabled, Turn data whitening off, Serial Synchronous mode
+  writeRegister(CC1101_ADDR , 0x00);		//00000000
+  writeRegister(CC1101_PKTLEN , 0xFF);		//11111111	//Not used, no hardware packet handling
 
-	writeRegister(CC1101_MDMCFG4 ,0x08);	//00001000
-	writeRegister(CC1101_MDMCFG3 ,0x43);	//01000011
-	writeRegister(CC1101_DEVIATN ,0x40);	//01000000
-	writeRegister(CC1101_IOCFG0 ,0x2D);		//GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
-	writeRegister(CC1101_IOCFG1 ,0x0B);		//Serial Clock. Synchronous to the data in synchronous serial mode.
-	
-	writeCommand(CC1101_STX);
-	writeCommand(CC1101_SIDLE);
-	delayMicroseconds(1);
-	writeCommand(CC1101_SIDLE);
+  //0x6F,0x26,0x2E,0x8C,0x87,0xCD,0xC7,0xC0
+  writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, (uint8_t*)ithoPaTableSend, 8);
 
-	writeRegister(CC1101_MDMCFG4 ,0x08);	//00001000
-	writeRegister(CC1101_MDMCFG3 ,0x43);	//01000011
-	writeRegister(CC1101_DEVIATN ,0x40);	//01000000
-	//writeRegister(CC1101_IOCFG0 ,0x2D);		//GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
-	//writeRegister(CC1101_IOCFG1 ,0x0B);		//Serial Clock. Synchronous to the data in synchronous serial mode.
-	
-	//Itho is using serial mode for transmit. We want to use the TX FIFO with fixed packet length for simplicity.
-	writeRegister(CC1101_IOCFG0 ,0x2E);
-	writeRegister(CC1101_IOCFG1 ,0x2E);	
-	writeRegister(CC1101_PKTLEN , 19);
-	writeRegister(CC1101_PKTCTRL0 ,0x00);
-	writeRegister(CC1101_PKTCTRL1 ,0x00);	
-}
+  //difference, message1 sends a STX here
+  writeCommand(CC1101_SIDLE);
+  writeCommand(CC1101_SIDLE);
 
-void IthoCC1101::initSendMessage2(IthoCommand command)
-{
-	//finishTransfer();
-	writeCommand(CC1101_SIDLE);
-	delayMicroseconds(1);
-	writeRegister(CC1101_IOCFG0 ,0x2E);
-	delayMicroseconds(1);
-	writeRegister(CC1101_IOCFG1 ,0x2E);
-	delayMicroseconds(1);
-	writeCommand(CC1101_SIDLE);
-	writeCommand(CC1101_SPWD);
-	delayMicroseconds(2);
-	
-	/*
-	Configuration reverse engineered from remote print. The commands below are used by IthoDaalderop.
-		
-	Base frequency		868.299866MHz
-	Channel				0
-	Channel spacing		199.951172kHz
-	Carrier frequency	868.299866MHz
-	Xtal frequency		26.000000MHz
-	Data rate			38.3835kBaud
-	Manchester			disabled
-	Modulation			2-FSK
-	Deviation			50.781250kHz
-	TX power			?
-	PA ramping			enabled
-	Whitening			disabled
-	*/	
-	writeCommand(CC1101_SRES);
-	delayMicroseconds(1);
-	writeRegister(CC1101_IOCFG0 ,0x2E);		//High impedance (3-state)
-	writeRegister(CC1101_FREQ2 ,0x21);		//00100001	878MHz-927.8MHz
-	writeRegister(CC1101_FREQ1 ,0x65);		//01100101
-	writeRegister(CC1101_FREQ0 ,0x6A);		//01101010	
-	writeRegister(CC1101_MDMCFG4 ,0x5A);	//difference compared to message1
-	writeRegister(CC1101_MDMCFG3 ,0x83);	//difference compared to message1
-	writeRegister(CC1101_MDMCFG2 ,0x00);	//00000000	2-FSK, no manchester encoding/decoding, no preamble/sync
-	writeRegister(CC1101_MDMCFG1 ,0x22);	//00100010
-	writeRegister(CC1101_MDMCFG0 ,0xF8);	//11111000
-	writeRegister(CC1101_CHANNR ,0x00);		//00000000
-	writeRegister(CC1101_DEVIATN ,0x50);	//difference compared to message1
-	writeRegister(CC1101_FREND0 ,0x17);		//00010111	use index 7 in PA table
-	writeRegister(CC1101_MCSM0 ,0x18);		//00011000	PO timeout Approx. 146µs - 171µs, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
-	writeRegister(CC1101_FSCAL3 ,0xA9);		//10101001
-	writeRegister(CC1101_FSCAL2 ,0x2A);		//00101010
-	writeRegister(CC1101_FSCAL1 ,0x00);		//00000000
-	writeRegister(CC1101_FSCAL0 ,0x11);		//00010001
-	writeRegister(CC1101_FSTEST ,0x59);		//01011001	For test only. Do not write to this register.
-	writeRegister(CC1101_TEST2 ,0x81);		//10000001	For test only. Do not write to this register.
-	writeRegister(CC1101_TEST1 ,0x35);		//00110101	For test only. Do not write to this register.
-	writeRegister(CC1101_TEST0 ,0x0B);		//00001011	For test only. Do not write to this register.
-	writeRegister(CC1101_PKTCTRL0 ,0x12);	//00010010	Enable infinite length packets, CRC disabled, Turn data whitening off, Serial Synchronous mode
-	writeRegister(CC1101_ADDR ,0x00);		//00000000
-	writeRegister(CC1101_PKTLEN ,0xFF);		//11111111	//Not used, no hardware packet handling
+  writeRegister(CC1101_MDMCFG4 , 0x5A);	//difference compared to message1
+  writeRegister(CC1101_MDMCFG3 , 0x83);	//difference compared to message1
+  writeRegister(CC1101_DEVIATN , 0x50);	//difference compared to message1
+  writeRegister(CC1101_IOCFG0 , 0x2D);		//GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
+  writeRegister(CC1101_IOCFG1 , 0x0B);		//Serial Clock. Synchronous to the data in synchronous serial mode.
 
-	//0x6F,0x26,0x2E,0x8C,0x87,0xCD,0xC7,0xC0
-	writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, (uint8_t*)ithoPaTableSend, 8);
+  writeCommand(CC1101_STX);
+  writeCommand(CC1101_SIDLE);
 
-	//difference, message1 sends a STX here
-	writeCommand(CC1101_SIDLE);
-	writeCommand(CC1101_SIDLE);
+  writeRegister(CC1101_MDMCFG4 , 0x5A);	//difference compared to message1
+  writeRegister(CC1101_MDMCFG3 , 0x83);	//difference compared to message1
+  writeRegister(CC1101_DEVIATN , 0x50);	//difference compared to message1
+  //writeRegister(CC1101_IOCFG0 ,0x2D);		//GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
+  //writeRegister(CC1101_IOCFG1 ,0x0B);		//Serial Clock. Synchronous to the data in synchronous serial mode.
 
-	writeRegister(CC1101_MDMCFG4 ,0x5A);	//difference compared to message1
-	writeRegister(CC1101_MDMCFG3 ,0x83);	//difference compared to message1
-	writeRegister(CC1101_DEVIATN ,0x50);	//difference compared to message1
-	writeRegister(CC1101_IOCFG0 ,0x2D);		//GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
-	writeRegister(CC1101_IOCFG1 ,0x0B);		//Serial Clock. Synchronous to the data in synchronous serial mode.
+  //Itho is using serial mode for transmit. We want to use the TX FIFO with fixed packet length for simplicity.
+  writeRegister(CC1101_IOCFG0 , 0x2E);
+  writeRegister(CC1101_IOCFG1 , 0x2E);
+  writeRegister(CC1101_PKTCTRL0 , 0x00);
+  writeRegister(CC1101_PKTCTRL1 , 0x00);
 
-	writeCommand(CC1101_STX);
-	writeCommand(CC1101_SIDLE);
+  writeRegister(CC1101_PKTLEN , len);
 
-	writeRegister(CC1101_MDMCFG4 ,0x5A);	//difference compared to message1
-	writeRegister(CC1101_MDMCFG3 ,0x83);	//difference compared to message1
-	writeRegister(CC1101_DEVIATN ,0x50);	//difference compared to message1
-	//writeRegister(CC1101_IOCFG0 ,0x2D);		//GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
-	//writeRegister(CC1101_IOCFG1 ,0x0B);		//Serial Clock. Synchronous to the data in synchronous serial mode.
-
-	//Itho is using serial mode for transmit. We want to use the TX FIFO with fixed packet length for simplicity.
-	writeRegister(CC1101_IOCFG0 ,0x2E);
-	writeRegister(CC1101_IOCFG1 ,0x2E);
-	writeRegister(CC1101_PKTCTRL0 ,0x00);
-	writeRegister(CC1101_PKTCTRL1 ,0x00);
-	
-	switch (command)
-	{
-		case IthoJoin:
-			writeRegister(CC1101_PKTLEN , 72);
-			break;
-			
-		case IthoLeave:
-			writeRegister(CC1101_PKTLEN , 57);
-			break;
-		
-		default:
-			writeRegister(CC1101_PKTLEN , 50);		
-			break;
-	}
 }
 
 void IthoCC1101::finishTransfer()
 {
-	writeCommand(CC1101_SIDLE);
-	delayMicroseconds(1);
+  writeCommand(CC1101_SIDLE);
+  delayMicroseconds(1);
 
-	writeRegister(CC1101_IOCFG0 ,0x2E);
-	writeRegister(CC1101_IOCFG1 ,0x2E);
-	
-	writeCommand(CC1101_SIDLE);
-	writeCommand(CC1101_SPWD);
+  writeRegister(CC1101_IOCFG0 , 0x2E);
+  writeRegister(CC1101_IOCFG1 , 0x2E);
+
+  writeCommand(CC1101_SIDLE);
+  writeCommand(CC1101_SPWD);
 }
 
 void IthoCC1101::initReceive()
 {
-	/*
-	Configuration reverse engineered from RFT print.
-	
-	Base frequency		868.299866MHz
-	Channel				0
-	Channel spacing		199.951172kHz
-	Carrier frequency	868.299866MHz
-	Xtal frequency		26.000000MHz
-	Data rate			38.3835kBaud
-	RX filter BW		325.000000kHz
-	Manchester			disabled
-	Modulation			2-FSK
-	Deviation			50.781250kHz
-	TX power			0x6F,0x26,0x2E,0x7F,0x8A,0x84,0xCA,0xC4
-	PA ramping			enabled
-	Whitening			disabled
-	*/	
-	writeCommand(CC1101_SRES);
+  /*
+    Configuration reverse engineered from RFT print.
 
-	writeRegister(CC1101_TEST0 ,0x09);
-	writeRegister(CC1101_FSCAL2 ,0x00);
-	
-	//0x6F,0x26,0x2E,0x7F,0x8A,0x84,0xCA,0xC4
-	writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, (uint8_t*)ithoPaTableReceive, 8);
-	
-	writeCommand(CC1101_SCAL);
+    Base frequency		868.299866MHz
+    Channel				0
+    Channel spacing		199.951172kHz
+    Carrier frequency	868.299866MHz
+    Xtal frequency		26.000000MHz
+    Data rate			38.3835kBaud
+    RX filter BW		325.000000kHz
+    Manchester			disabled
+    Modulation			2-FSK
+    Deviation			50.781250kHz
+    TX power			0x6F,0x26,0x2E,0x7F,0x8A,0x84,0xCA,0xC4
+    PA ramping			enabled
+    Whitening			disabled
+  */
+  writeCommand(CC1101_SRES);
 
-	//wait for calibration to finish
-	while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE) yield();
+  writeRegister(CC1101_TEST0 , 0x09);
+  writeRegister(CC1101_FSCAL2 , 0x00);
 
-	writeRegister(CC1101_FSCAL2 ,0x00);
-	writeRegister(CC1101_MCSM0 ,0x18);			//no auto calibrate
-	writeRegister(CC1101_FREQ2 ,0x21);
-	writeRegister(CC1101_FREQ1 ,0x65);
-	writeRegister(CC1101_FREQ0 ,0x6A);
-	writeRegister(CC1101_IOCFG0 ,0x2E);			//High impedance (3-state)
-	writeRegister(CC1101_IOCFG2 ,0x00);			//Assert when RX FIFO is filled or above the RX FIFO threshold. Deassert when (0x00): RX FIFO is drained below threshold, or (0x01): deassert when RX FIFO is empty.
-	writeRegister(CC1101_FSCTRL1 ,0x06);
-	writeRegister(CC1101_FSCTRL0 ,0x00);
-	writeRegister(CC1101_MDMCFG4 ,0xE8);
-	writeRegister(CC1101_MDMCFG3 ,0x43);
-	writeRegister(CC1101_MDMCFG2 ,0x00);		//Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync 
-	writeRegister(CC1101_MDMCFG1 ,0x22);		//Disable FEC
-	writeRegister(CC1101_MDMCFG0 ,0xF8);
-	writeRegister(CC1101_CHANNR ,0x00);
-	writeRegister(CC1101_DEVIATN ,0x40);
-	writeRegister(CC1101_FREND1 ,0x56);
-	writeRegister(CC1101_FREND0 ,0x17);
-	writeRegister(CC1101_MCSM0 ,0x18);			//no auto calibrate
-	writeRegister(CC1101_FOCCFG ,0x16);
-	writeRegister(CC1101_BSCFG ,0x6C);
-	writeRegister(CC1101_AGCCTRL2 ,0x43);
-	writeRegister(CC1101_AGCCTRL1 ,0x40);
-	writeRegister(CC1101_AGCCTRL0 ,0x91);
-	writeRegister(CC1101_FSCAL3 ,0xA9);
-	writeRegister(CC1101_FSCAL2 ,0x2A);
-	writeRegister(CC1101_FSCAL1 ,0x00);
-	writeRegister(CC1101_FSCAL0 ,0x1F);
-	writeRegister(CC1101_FSTEST ,0x59);
-	writeRegister(CC1101_TEST2 ,0x81);
-	writeRegister(CC1101_TEST1 ,0x35);
-	writeRegister(CC1101_TEST0 ,0x0B);
-	writeRegister(CC1101_PKTCTRL1 ,0x04);		//No address check, Append two bytes with status RSSI/LQI/CRC OK, 
-	writeRegister(CC1101_PKTCTRL0 ,0x32);		//Infinite packet length mode, CRC disabled for TX and RX, No data whitening, Asynchronous serial mode, Data in on GDO0 and data out on either of the GDOx pins 
-	writeRegister(CC1101_ADDR ,0x00);
-	writeRegister(CC1101_PKTLEN ,0xFF);
-	writeRegister(CC1101_TEST0 ,0x09);
+  //0x6F,0x26,0x2E,0x7F,0x8A,0x84,0xCA,0xC4
+  writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, (uint8_t*)ithoPaTableReceive, 8);
 
-	writeCommand(CC1101_SCAL);
+  writeCommand(CC1101_SCAL);
 
-	//wait for calibration to finish
-	while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE) yield();
+  //wait for calibration to finish
+  while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE) yield();
 
-	writeRegister(CC1101_MCSM0 ,0x18);			//no auto calibrate
-	
-	writeCommand(CC1101_SIDLE);
-	writeCommand(CC1101_SIDLE);
-	
-	writeRegister(CC1101_MDMCFG2 ,0x00);		//Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync 
-	writeRegister(CC1101_IOCFG0 ,0x0D);			//Serial Data Output. Used for asynchronous serial mode.
+  writeRegister(CC1101_FSCAL2 , 0x00);
+  writeRegister(CC1101_MCSM0 , 0x18);			//no auto calibrate
+  writeRegister(CC1101_FREQ2 , 0x21);
+  writeRegister(CC1101_FREQ1 , 0x65);
+  writeRegister(CC1101_FREQ0 , 0x6A);
+  writeRegister(CC1101_IOCFG0 , 0x2E);			//High impedance (3-state)
+  writeRegister(CC1101_IOCFG2 , 0x06);			//0x06 Assert when sync word has been sent / received, and de-asserts at the end of the packet.
+  writeRegister(CC1101_FSCTRL1 , 0x06);
+  writeRegister(CC1101_FSCTRL0 , 0x00);
+  writeRegister(CC1101_MDMCFG4 , 0x5A);
+  writeRegister(CC1101_MDMCFG3 , 0x83);
+  writeRegister(CC1101_MDMCFG2 , 0x00);		//Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
+  writeRegister(CC1101_MDMCFG1 , 0x22);		//Disable FEC
+  writeRegister(CC1101_MDMCFG0 , 0xF8);
+  writeRegister(CC1101_CHANNR , 0x00);
+  writeRegister(CC1101_DEVIATN , 0x50);
+  writeRegister(CC1101_FREND1 , 0x56);
+  writeRegister(CC1101_FREND0 , 0x17);
+  writeRegister(CC1101_MCSM0 , 0x18);			//no auto calibrate
+  writeRegister(CC1101_FOCCFG , 0x16);
+  writeRegister(CC1101_BSCFG , 0x6C);
+  writeRegister(CC1101_AGCCTRL2 , 0x43);
+  writeRegister(CC1101_AGCCTRL1 , 0x40);
+  writeRegister(CC1101_AGCCTRL0 , 0x91);
+  writeRegister(CC1101_FSCAL3 , 0xE9);
+  writeRegister(CC1101_FSCAL2 , 0x2A);
+  writeRegister(CC1101_FSCAL1 , 0x00);
+  writeRegister(CC1101_FSCAL0 , 0x11);
+  writeRegister(CC1101_FSTEST , 0x59);
+  writeRegister(CC1101_TEST2 , 0x81);
+  writeRegister(CC1101_TEST1 , 0x35);
+  writeRegister(CC1101_TEST0 , 0x0B);
+  writeRegister(CC1101_PKTCTRL1 , 0x04);		//No address check, Append two bytes with status RSSI/LQI/CRC OK,
+  writeRegister(CC1101_PKTCTRL0 , 0x32);		//Infinite packet length mode, CRC disabled for TX and RX, No data whitening, Asynchronous serial mode, Data in on GDO0 and data out on either of the GDOx pins
+  writeRegister(CC1101_ADDR , 0x00);
+  writeRegister(CC1101_PKTLEN , 0xFF);
+  writeRegister(CC1101_TEST0 , 0x09);
 
-	writeCommand(CC1101_SRX);
-	
-	while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_RX) yield();
-	
-//	initReceiveMessage2(IthoUnknown);
-	initReceiveMessage2(ithomsg_unknown);
+  writeCommand(CC1101_SCAL);
+
+  //wait for calibration to finish
+  while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE) yield();
+
+  writeRegister(CC1101_MCSM0 , 0x18);			//no auto calibrate
+
+  writeCommand(CC1101_SIDLE);
+  writeCommand(CC1101_SIDLE);
+
+  writeRegister(CC1101_MDMCFG2 , 0x00);		//Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
+  writeRegister(CC1101_IOCFG0 , 0x0D);			//Serial Data Output. Used for asynchronous serial mode.
+
+  writeCommand(CC1101_SRX);
+
+  while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_RX) yield();
+
+  initReceiveMessage();
 }
 
-//void  IthoCC1101::initReceiveMessage2(IthoCommand expectedCommand)
-void  IthoCC1101::initReceiveMessage2(IthoMessageType expectedMessageType)
+void  IthoCC1101::initReceiveMessage()
 {
-	uint8_t marcState;
-	
-	writeCommand(CC1101_SIDLE);	//idle
-	
-	//set datarate	
-	writeRegister(CC1101_MDMCFG4 ,0x9A); // set kBaud
-	writeRegister(CC1101_MDMCFG3 ,0x83); // set kBaud
-	writeRegister(CC1101_DEVIATN ,0x50);
-	
- 	//set fifo mode with fixed packet length and sync bytes
-	writeRegister(CC1101_PKTLEN ,42);			//42 bytes message (sync at beginning of message is removed by CC1101)
-	receiveState = ExpectNormalCommand;
-	
-	//set fifo mode with fixed packet length and sync bytes
-	writeRegister(CC1101_PKTCTRL0 ,0x00);
-	writeRegister(CC1101_SYNC1 ,170);			//message2 byte6
-	writeRegister(CC1101_SYNC0 ,171);			//message2 byte7
-	writeRegister(CC1101_MDMCFG2 ,0x02);
-	writeRegister(CC1101_PKTCTRL1 ,0x00);	
-	
-	writeCommand(CC1101_SRX); //switch to RX state
+  uint8_t marcState;
 
-	// Check that the RX state has been entered
-	while (((marcState = readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) & CC1101_BITS_MARCSTATE) != CC1101_MARCSTATE_RX)
-	{
-		if (marcState == CC1101_MARCSTATE_RXFIFO_OVERFLOW) // RX_OVERFLOW
-			writeCommand(CC1101_SFRX); //flush RX buffer
-	}
+  writeCommand(CC1101_SIDLE);	//idle
+
+  //set datarate
+  writeRegister(CC1101_MDMCFG4 , 0x5A); // set kBaud
+  writeRegister(CC1101_MDMCFG3 , 0x83); // set kBaud
+  writeRegister(CC1101_DEVIATN , 0x50);
+
+  //set fifo mode with fixed packet length and sync bytes
+  writeRegister(CC1101_PKTLEN , 63);			//63 bytes message (sync at beginning of message is removed by CC1101)
+
+  //set fifo mode with fixed packet length and sync bytes
+  writeRegister(CC1101_PKTCTRL0 , 0x00);
+  writeRegister(CC1101_SYNC1 , 163);			//message2 byte11 = 179, byte13 = 171 with SYNC1 = 163, 179 and 171 differ only by 1 bit
+  writeRegister(CC1101_SYNC0 , 42);			  //message2 byte12,14
+  writeRegister(CC1101_MDMCFG2 , 0x03);   //32bit sync word / 30bit specific
+  writeRegister(CC1101_PKTCTRL1 , 0x00);
+
+  writeCommand(CC1101_SRX); //switch to RX state
+
+  // Check that the RX state has been entered
+  while (((marcState = readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) & CC1101_BITS_MARCSTATE) != CC1101_MARCSTATE_RX)
+  {
+    if (marcState == CC1101_MARCSTATE_RXFIFO_OVERFLOW) // RX_OVERFLOW
+      writeCommand(CC1101_SFRX); //flush RX buffer
+  }
 }
 
 bool IthoCC1101::checkForNewPacket()
 {
-	if (receiveData(&inMessage2, 42))
-	{
-		parseMessageCommand();
-		initReceiveMessage2(ithomsg_unknown);
-		return true;
-	}	
-	
-	return false;
+  if (receiveData(&inMessage, 63))
+  {
+    parseMessageCommand();
+    initReceiveMessage();
+    return true;
+  }
+
+  return false;
 }
 
 void IthoCC1101::parseMessageCommand()
 {
-	bool isPowerCommand = true;
-	bool isHighCommand = true;
-	bool isMediumCommand = true;
-	bool isLowCommand = true;
-	bool isStandByCommand = true;
-	bool isTimer1Command = true;
-	bool isTimer2Command = true;
-	bool isTimer3Command = true;
-	bool isJoinCommand = true;
-	bool isLeaveCommand = true;
+  bool isPowerCommand = true;
+  bool isHighCommand = true;
+  bool isRVHighCommand = true;
+  bool isMediumCommand = true;
+  bool isRVMediumCommand = true;
+  bool isLowCommand = true;
+  bool isRVLowCommand = true;
+  bool isRVAutoCommand = true;
+  bool isStandByCommand = true;
+  bool isTimer1Command = true;
+  bool isTimer2Command = true;
+  bool isTimer3Command = true;
+  bool isJoinCommand = true;
+  bool isJoin2Command = true;
+  bool isRVJoinCommand = true;
+  bool isLeaveCommand = true;
 
-	//device id
-	memcpy(inIthoPacket.deviceId2, &inMessage2.data[8], sizeof inIthoPacket.deviceId2);
-	
-	//counter1
-	inIthoPacket.counter = calculateMessageCounter(inMessage2.data[16], inMessage2.data[17], (inMessage2.data[16] & 0b11110000));
+  messageDecode(&inMessage, &inIthoPacket);
 
-	//match received commandBytes from inMessage2 [offset is +18] with known command bytes
-	//and for simpcity sake we ignore the first 11 bytes: the last 4 bytes are still unique
-	for (int i=11; i<15; i++)
-	{
-		if (inMessage2.data[i+18] != ithoMessage2PowerCommandBytes[i])   isPowerCommand = false;
-		if (inMessage2.data[i+18] != ithoMessage2HighCommandBytes[i])    isHighCommand = false;
-		if (inMessage2.data[i+18] != ithoMessage2MediumCommandBytes[i])  isMediumCommand = false;
-		if (inMessage2.data[i+18] != ithoMessage2LowCommandBytes[i])     isLowCommand = false;
-		if (inMessage2.data[i+18] != ithoMessage2StandByCommandBytes[i]) isStandByCommand = false;
-		if (inMessage2.data[i+18] != ithoMessage2Timer1CommandBytes[i])  isTimer1Command = false;
-		if (inMessage2.data[i+18] != ithoMessage2Timer2CommandBytes[i])  isTimer2Command = false;
-		if (inMessage2.data[i+18] != ithoMessage2Timer3CommandBytes[i])  isTimer3Command = false;
-		if (inMessage2.data[i+18] != ithoMessage2JoinCommandBytes[i])    isJoinCommand = false;
-		if (inMessage2.data[i+18] != ithoMessage2LeaveCommandBytes[i])   isLeaveCommand = false;
-	}	
-		
-	//determine command
-	inIthoPacket.command = IthoUnknown;
-	if (isPowerCommand)   inIthoPacket.command = IthoFull;
-	if (isHighCommand)    inIthoPacket.command = IthoHigh;
-	if (isMediumCommand)  inIthoPacket.command = IthoMedium;
-	if (isLowCommand)     inIthoPacket.command = IthoLow;
-	if (isStandByCommand) inIthoPacket.command = IthoStandby;
-	if (isTimer1Command)  inIthoPacket.command = IthoTimer1;
-	if (isTimer2Command)  inIthoPacket.command = IthoTimer2;
-	if (isTimer3Command)  inIthoPacket.command = IthoTimer3;
-	if (isJoinCommand)    inIthoPacket.command = IthoJoin;
-	if (isLeaveCommand)   inIthoPacket.command = IthoLeave;	
+  //counter1
+  inIthoPacket.counter = inIthoPacket.dataDecoded[4];
+
+  //match received commandBytes from dataDecoded [offset is +5] with known command bytes
+  //the first 2 and last 2 bytes seem to be unique and universal
+  uint8_t offset = 0;
+  if (inIthoPacket.deviceType == 28 || inIthoPacket.deviceType == 24) offset = 2;
+  for (int i = 0; i < 6; i++)
+  {
+    if (i == 2) continue; //skip byte3, rft-rv device seem to sometimes have a different number there for Timer command
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessagePowerCommandBytes[i])    isPowerCommand    = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageHighCommandBytes[i])     isHighCommand     = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageRVHighCommandBytes[i])   isRVHighCommand   = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageMediumCommandBytes[i])   isMediumCommand   = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageRVMediumCommandBytes[i]) isRVMediumCommand = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageLowCommandBytes[i])      isLowCommand      = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageRVLowCommandBytes[i])    isRVLowCommand    = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageRVAutoCommandBytes[i])   isRVAutoCommand   = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageStandByCommandBytes[i])  isStandByCommand  = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageTimer1CommandBytes[i])   isTimer1Command   = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageTimer2CommandBytes[i])   isTimer2Command   = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageTimer3CommandBytes[i])   isTimer3Command   = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageJoinCommandBytes[i])     isJoinCommand     = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageJoin2CommandBytes[i])    isJoin2Command    = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageRVJoinCommandBytes[i])   isRVJoinCommand   = false;
+    if (inIthoPacket.dataDecoded[i + 5 + offset] != ithoMessageLeaveCommandBytes[i])    isLeaveCommand    = false;
+  }
+  //determine command
+  inIthoPacket.command = IthoUnknown;
+  if (isPowerCommand)    inIthoPacket.command = IthoFull;
+  if (isHighCommand)     inIthoPacket.command = IthoHigh;
+  if (isRVHighCommand)   inIthoPacket.command = IthoHigh;
+  if (isMediumCommand)   inIthoPacket.command = IthoMedium;
+  if (isRVMediumCommand) inIthoPacket.command = IthoMedium;
+  if (isLowCommand)      inIthoPacket.command = IthoLow;
+  if (isRVLowCommand)    inIthoPacket.command = IthoLow;
+  if (isRVAutoCommand)   inIthoPacket.command = IthoStandby;
+  if (isStandByCommand)  inIthoPacket.command = IthoStandby;
+  if (isTimer1Command)   inIthoPacket.command = IthoTimer1;
+  if (isTimer2Command)   inIthoPacket.command = IthoTimer2;
+  if (isTimer3Command)   inIthoPacket.command = IthoTimer3;
+  if (isJoinCommand)     inIthoPacket.command = IthoJoin;
+  if (isJoin2Command)    inIthoPacket.command = IthoJoin;
+  if (isRVJoinCommand)   inIthoPacket.command = IthoJoin;
+  if (isLeaveCommand)    inIthoPacket.command = IthoLeave;
 }
 
 void IthoCC1101::sendCommand(IthoCommand command)
 {
-//	CC1101Packet outMessage1;
-	CC1101Packet outMessage2;
-	uint8_t maxTries = sendTries;
-	uint8_t delaytime = 40;
-	
-	//update itho packet data
-	outIthoPacket.previous = outIthoPacket.command;
-	outIthoPacket.messageType = ithomsg_unknown;
-	outIthoPacket.command = command;
-	outIthoPacket.counter += 1;
-	
-	//get message1 bytes
-	//createMessageStart(&outIthoPacket, &outMessage1);
-	
-	//get message2 bytes
-	switch (command)
-	{
-		case IthoJoin:
-			createMessageJoin(&outIthoPacket, &outMessage2);
-			break;
-		
-		case IthoLeave:
-			createMessageLeave(&outIthoPacket, &outMessage2);
-			//the leave command needs to be transmitted for 1 second according the manual
-			maxTries = 30;
-			delaytime = 4;
-			break;
-		
-		default:
-			createMessageCommand(&outIthoPacket, &outMessage2);
-			break;
-	}
-	
-	//send messages
-	for (int i=0;i<maxTries;i++)
-	{
-/*		//message1
-		initSendMessage1();
-		sendData(&outMessage1);
+  CC1101Packet outMessage;
+  uint8_t maxTries = sendTries;
+  uint8_t delaytime = 40;
 
-		delay(4); */ // delay between message1/2
-		
-		//message2
-		initSendMessage2(outIthoPacket.command);
-		sendData(&outMessage2);
-		
-		finishTransfer();
-		delay(delaytime);
-	}
-    initReceive();
+  //update itho packet data
+  outIthoPacket.command = command;
+  outIthoPacket.counter += 1;
+
+  //get message2 bytes
+  switch (command)
+  {
+    case IthoJoin:
+      createMessageJoin(&outIthoPacket, &outMessage);
+      break;
+
+    case IthoLeave:
+      createMessageLeave(&outIthoPacket, &outMessage);
+      //the leave command needs to be transmitted for 1 second according the manual
+      maxTries = 30;
+      delaytime = 4;
+      break;
+
+    default:
+      createMessageCommand(&outIthoPacket, &outMessage);
+      break;
+  }
+
+  if (DEBUG == 2) {
+    char buf[32];
+    Serial.println();
+    Serial.print("outMessage length: "); Serial.print(outMessage.length); Serial.println(" bytes; outMessage bit pattern: ");
+    for (int i = 0; i < outMessage.length; i++) {
+      strcpy(buf, "");
+      sprintf(buf, BYTE_TO_BINARY_PATTERN, BYTE_TO_BINARY(outMessage.data[i]));
+      Serial.print(buf);
+    }
+    Serial.println();
+  }
+
+  //send messages
+  for (int i = 0; i < maxTries; i++)
+  {
+
+    //message2
+    initSendMessage(outMessage.length);
+    sendData(&outMessage);
+
+    finishTransfer();
+    delay(delaytime);
+  }
+  initReceive();
 }
+
 
 void IthoCC1101::createMessageStart(IthoPacket *itho, CC1101Packet *packet)
 {
-	packet->length = 19;
 
-	//fixed
-	packet->data[0] = 170;
-	packet->data[1] = 170;
-	packet->data[2] = 170;	
-	packet->data[3] = 173;
-	
-	//device id message 1
-	packet->data[4] = itho->deviceId1[0];
-	packet->data[5] = itho->deviceId1[1];	
-	packet->data[6] = itho->deviceId1[2];
-	packet->data[7] = itho->deviceId1[3];
-	packet->data[8] = itho->deviceId1[4];
-	packet->data[9] = itho->deviceId1[5];	//last bit is part of command
+  //fixed, set start structure in data buffer manually
+  for (uint8_t i = 0; i < 7; i++) {
+    packet->data[i] = 170;
+  }
+  packet->data[7] = 171;
+  packet->data[8] = 254;
+  packet->data[9] = 0;
+  packet->data[10] = 179;
+  packet->data[11] = 42;
+  packet->data[12] = 171;
+  packet->data[13] = 42;
 
-	//command
-	uint8_t *commandBytes = getMessage1CommandBytes(itho->command);
-	packet->data[9] = packet->data[9] | commandBytes[0];	//only last bit is set
-	packet->data[10] = commandBytes[1];
-	packet->data[11] = commandBytes[2];
-	packet->data[12] = commandBytes[3];
-	packet->data[13] = commandBytes[4];
-	packet->data[14] = commandBytes[5];
-	packet->data[15] = commandBytes[6];
-	
-	//fixed
-	packet->data[16] = 170;
-	packet->data[17] = 171;
+  //[start of command specific data]
 
-	//previous command
-	packet->data[18] = getMessage1Byte18(itho->previous);
 }
 
 void IthoCC1101::createMessageCommand(IthoPacket *itho, CC1101Packet *packet)
 {
-	packet->length = 50;
-	
-	//fixed
-	packet->data[0] = 170;
-	packet->data[1] = 170;
-	packet->data[2] = 170;
-	packet->data[3] = 170;
-	packet->data[4] = 170;
-	packet->data[5] = 170;
-	packet->data[6] = 170;				
-	packet->data[7] = 171;	
-	packet->data[8] = 254;				
-	packet->data[9] = 0;				
-	packet->data[10] = 179;				
-	packet->data[11] = 42;				
-	packet->data[12] = 171;				
-	packet->data[13] = 42;				
-	packet->data[14] = 149;				
-	packet->data[15] = 154;				
-	
-	//device id message 2
-	packet->data[16] = itho->deviceId2[0];
-	packet->data[17] = itho->deviceId2[1];
-	packet->data[18] = itho->deviceId2[2];
-	packet->data[19] = itho->deviceId2[3];
-	packet->data[20] = itho->deviceId2[4];
-	packet->data[21] = itho->deviceId2[5];
-	packet->data[22] = itho->deviceId2[6];
-	packet->data[23] = itho->deviceId2[7];
-	
-	//counter bytes
-	packet->data[24] = calculateMessage2Byte24(itho->counter);
-	packet->data[25] = calculateMessage2Byte25(itho->counter);
-	packet->data[26] = calculateMessage2Byte26(itho->counter);
 
-	//command
-	uint8_t *commandBytes = getMessage2CommandBytes(itho->command);
-	packet->data[26] = packet->data[26] | commandBytes[0];
-	packet->data[27] = commandBytes[1];
-	packet->data[28] = commandBytes[2];
-	packet->data[29] = commandBytes[3];
-	packet->data[30] = commandBytes[4];
-	packet->data[31] = commandBytes[5];
-	packet->data[32] = commandBytes[6];
-	packet->data[33] = commandBytes[7];
-	packet->data[34] = commandBytes[8];
-	packet->data[35] = commandBytes[9];
-	packet->data[36] = commandBytes[10];
-	packet->data[37] = commandBytes[11];
-	packet->data[38] = commandBytes[12];
-	packet->data[39] = commandBytes[13];	
-	packet->data[40] = commandBytes[14];
+  //set start message structure
+  createMessageStart(itho, packet);
 
-	//counter bytes
-	packet->data[41] = calculateMessage2Byte41(itho->counter, itho->command);
-	packet->data[42] = calculateMessage2Byte42(itho->counter, itho->command);
-	packet->data[43] = calculateMessage2Byte43(itho->counter, itho->command);
-	
-	//fixed
-	packet->data[44] = 172;
-	packet->data[45] = 170;
-	packet->data[46] = 170;
-	packet->data[47] = 170;	
-	packet->data[48] = 170;	
-	packet->data[49] = 170;	
+  //set deviceType? (or messageType?), not sure what this is
+  itho->dataDecoded[0] = itho->deviceType;
+
+  //set deviceID
+  itho->dataDecoded[1] = itho->deviceId[0];
+  itho->dataDecoded[2] = itho->deviceId[1];
+  itho->dataDecoded[3] = itho->deviceId[2];
+
+  //set counter1
+  itho->dataDecoded[4] = itho->counter;
+
+  //set command bytes on dataDecoded[5 - 10]
+  uint8_t *commandBytes = getMessageCommandBytes(itho->command);
+  for (uint8_t i = 0; i < 6; i++) {
+    itho->dataDecoded[i + 5] = commandBytes[i];
+  }
+
+  //set counter2
+  itho->dataDecoded[11] = getCounter2(itho, 11);
+
+  itho->length = 12;
+
+  packet->length = messageEncode(itho, packet);
+  packet->length += 1;
+
+  //set end byte
+  packet->data[packet->length] = 172;
+  packet->length += 1;
+
+  //set end 'noise'
+  for (uint8_t i = packet->length; i < packet->length + 7; i++) {
+    packet->data[i] = 170;
+  }
+  packet->length += 7;
+
 }
 
 void IthoCC1101::createMessageJoin(IthoPacket *itho, CC1101Packet *packet)
 {
-	//message3 is an extension on message2
-	createMessageCommand(itho, packet);
-		
-	packet->length = 72;
-	
-	//device id
-	packet->data[41] = itho->deviceId2[0];
-	packet->data[42] = itho->deviceId2[1];
-	packet->data[43] = itho->deviceId2[2];
-	packet->data[44] = itho->deviceId2[3];
-	packet->data[45] = itho->deviceId2[4];
-	packet->data[46] = itho->deviceId2[5];
-	packet->data[47] = itho->deviceId2[6];
-	packet->data[48] = itho->deviceId2[7];
-	
-	//command join
-	packet->data[49] = 85;
-	
-	//fixed
-	packet->data[50] = 165;
-	packet->data[51] = 105;
-	packet->data[52] = 89;
-	packet->data[53] = 86;
-	packet->data[54] = 106;
-	packet->data[55] = 149;
-	
-	//device id
-	packet->data[56] = itho->deviceId2[0];
-	packet->data[57] = itho->deviceId2[1];
-	packet->data[58] = itho->deviceId2[2];
-	packet->data[59] = itho->deviceId2[3];
-	packet->data[60] = itho->deviceId2[4];
-	packet->data[61] = itho->deviceId2[5];
-	packet->data[62] = itho->deviceId2[6];
-	packet->data[63] = itho->deviceId2[7];
-	
-	//counter bytes
-	packet->data[64] = calculateMessage2Byte64(itho->counter);
-	packet->data[65] = calculateMessage2Byte65(itho->counter);
-	packet->data[66] = calculateMessage2Byte66(itho->counter);
-	
-	//fixed
-	packet->data[67] = 202;
-	packet->data[68] = 170;
-	packet->data[69] = 170;
-	packet->data[70] = 170;
-	packet->data[71] = 170;
+
+  //set start message structure
+  createMessageStart(itho, packet);
+
+  //set deviceType? (or messageType?)
+  itho->dataDecoded[0] = itho->deviceType;
+
+  //set deviceID
+  itho->dataDecoded[1] = itho->deviceId[0];
+  itho->dataDecoded[2] = itho->deviceId[1];
+  itho->dataDecoded[3] = itho->deviceId[2];
+
+  //set counter1
+  itho->dataDecoded[4] = itho->counter;
+
+  //set command bytes on dataDecoded[5 - ?]
+  uint8_t *commandBytes = getMessageCommandBytes(itho->command);
+  for (uint8_t i = 0; i < 6; i++) {
+    itho->dataDecoded[i + 5] = commandBytes[i];
+  }
+
+  //set deviceID
+  itho->dataDecoded[11] = itho->deviceId[0];
+  itho->dataDecoded[12] = itho->deviceId[1];
+  itho->dataDecoded[13] = itho->deviceId[2];
+
+  itho->dataDecoded[14] = 1;
+  itho->dataDecoded[15] = 16;
+  itho->dataDecoded[16] = 224;
+
+  //set deviceID
+  itho->dataDecoded[17] = itho->deviceId[0];
+  itho->dataDecoded[18] = itho->deviceId[1];
+  itho->dataDecoded[19] = itho->deviceId[2];
+
+  //set counter2
+  itho->dataDecoded[20] = getCounter2(itho, 20);
+
+  itho->length = 21;
+
+  packet->length = messageEncode(itho, packet);
+  packet->length += 1;
+
+  //set end byte
+  packet->data[packet->length] = 202;
+  packet->length += 1;
+
+  //set end 'noise'
+  for (uint8_t i = packet->length; i < packet->length + 7; i++) {
+    packet->data[i] = 170;
+  }
+  packet->length += 7;
+
 }
 
 void IthoCC1101::createMessageLeave(IthoPacket *itho, CC1101Packet *packet)
 {
-	//message3 is an extension on message2
-	createMessageCommand(itho, packet);
-	
-	packet->length = 57;
-	
-	//device id
-	packet->data[41] = itho->deviceId2[0];
-	packet->data[42] = itho->deviceId2[1];
-	packet->data[43] = itho->deviceId2[2];
-	packet->data[44] = itho->deviceId2[3];
-	packet->data[45] = itho->deviceId2[4];
-	packet->data[46] = itho->deviceId2[5];
-	packet->data[47] = itho->deviceId2[6];
-	packet->data[48] = itho->deviceId2[7];
-	
-	//counter bytes
-	packet->data[49] = calculateMessage2Byte49(itho->counter);
-	packet->data[50] = calculateMessage2Byte50(itho->counter);
-	packet->data[51] = calculateMessage2Byte51(itho->counter);
-		
-	//fixed
-	packet->data[52] = 202;
-	packet->data[53] = 170;
-	packet->data[54] = 170;
-	packet->data[55] = 170;
-	packet->data[56] = 170;
+
+  //set start message structure
+  createMessageStart(itho, packet);
+
+  //set deviceType? (or messageType?)
+  itho->dataDecoded[0] = itho->deviceType;
+
+  //set deviceID
+  itho->dataDecoded[1] = itho->deviceId[0];
+  itho->dataDecoded[2] = itho->deviceId[1];
+  itho->dataDecoded[3] = itho->deviceId[2];
+
+  //set counter1
+  itho->dataDecoded[4] = itho->counter;
+
+  //set command bytes on dataDecoded[5 - 10]
+  uint8_t *commandBytes = getMessageCommandBytes(itho->command);
+  for (uint8_t i = 0; i < 6; i++) {
+    itho->dataDecoded[i + 5] = commandBytes[i];
+  }
+
+  //set deviceID
+  itho->dataDecoded[11] = itho->deviceId[0];
+  itho->dataDecoded[12] = itho->deviceId[1];
+  itho->dataDecoded[13] = itho->deviceId[2];
+
+  //set counter2
+  itho->dataDecoded[14] = getCounter2(itho, 14);
+
+  itho->length = 15;
+
+  packet->length = messageEncode(itho, packet);
+  packet->length += 1;
+
+  //set end byte
+  packet->data[packet->length] = 202;
+  packet->length += 1;
+
+  //set end 'noise'
+  for (uint8_t i = packet->length; i < packet->length + 7; i++) {
+    packet->data[i] = 170;
+  }
+  packet->length += 7;
+
 }
 
-//calculate 0-255 number out of 3 counter bytes
-uint8_t IthoCC1101::calculateMessageCounter(uint8_t byte24, uint8_t byte25, uint8_t byte26)
+uint8_t* IthoCC1101::getMessageCommandBytes(IthoCommand command)
 {
-	uint8_t result;
-	
-	uint8_t a = getCounterIndex(&counterBytes24a[0],2,byte24 & 0b00000011);	//last 2 bits only
-	uint8_t b = getCounterIndex(&counterBytes24b[0],8,byte24 & 0b11111100);	//first 6 bits
-	uint8_t c = getCounterIndex(&counterBytes25[0],8,byte25);
-	uint8_t d = getCounterIndex(&counterBytes26[0],2,byte26);
-	
-	result = (a * 128) + (b * 16) + (d * 8) + c;
-	
-	return result;
-}
-
-IthoCommand IthoCC1101::getMessage1PreviousCommand(uint8_t byte18)
-{
-	switch (byte18)
-	{
-		case 77:
-			return IthoJoin;
-			
-		case 82:
-			return IthoLeave;
-			
-//		case 85:
-		default:
-			return IthoLow;
-	}
-}
-
-uint8_t IthoCC1101::getMessage1Byte18(IthoCommand command)
-{
-	switch (command)
-	{
-		case IthoJoin:
-			return 77;
-		
-		case IthoLeave:
-			return 82;
-		
-		default:
-			return 85;
-	}
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte24(uint8_t counter)
-{
-	return counterBytes24a[(counter / 128)] | counterBytes24b[(counter % 128) / 16];	
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte25(uint8_t counter)
-{
-	return counterBytes25[(counter % 16) % 8];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte26(uint8_t counter)
-{
-	return counterBytes26[(counter % 16) / 8];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte41(uint8_t counter, IthoCommand command)
-{
-	int var = 0;
-	uint8_t hi = 0;
-	
-	switch (command)
-	{
-		case IthoTimer1:
-		case IthoTimer3:
-			hi = 160;
-			var = 48 - command;
-			if (counter < var) counter = 64 - counter;
-			break;
-			
-		case IthoJoin:
-			hi = 96;
-			counter = 0;
-			break;
-				
-		case IthoLeave:
-			hi = 160;
-			counter = 0;
-			break;
-							
-		default:
-			hi = 96;
-			var = 48 - command;
-			if (counter < var) counter = 74 - counter;
-			break;		
-	}
-
-	return (hi | counterBytes41[((counter - var) % 64) / 16]);
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte42(uint8_t counter, IthoCommand command)
-{
-	uint8_t result;
-	
-	if (command == IthoJoin || command == IthoLeave)
-	{
-		counter = 1;
-	}
-	else
-	{
-		counter += command;
-	}
-
-	result = counterBytes42[counter / 64];
-
-	if (counter % 2 == 1) result -= 1;
-		
-	return result;
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte43(uint8_t counter, IthoCommand command)
-{
-	switch (command)
-	{
-		case IthoFull:
-			counter += 3;
-			if (counter % 2 == 0) counter -= 1;
-			break;
-			
-		case IthoHigh:
-			counter += 2;
-			if (counter % 2 == 0) counter -= 1;
-			break;
-			
-		case IthoUnknown:
-		case IthoMedium:
-			break;
-				
-		case IthoLow:
-		case IthoTimer2:
-			if (counter % 2 == 0) counter -= 1;
-			break;
-			
-		case IthoStandby:
-			counter -= 1;
-			if (counter % 2 == 0) counter -= 1;
-			break;			
-
-			case IthoTimer1:
-			counter += 6;
-			if (counter % 2 == 0) counter -= 1;		
-			break;
-			
-		case IthoTimer3:
-			counter += 10;
-			if (counter % 2 == 0) counter -= 1;		
-			break;
-			
-		case IthoJoin:
-		case IthoLeave:
-			counter = 0;
-			break;	
-
-		case DucoHigh:
-			counter += 10;
-			if (counter % 2 != 0) counter -= 1;
-			break;
-
-		case DucoMedium:
-			counter += 9;
-			if (counter % 2 != 0) counter -= 1;
-			break;
-
-		case DucoLow:
-			counter += 8;
-			break;
-
-		case DucoStandby:
-			counter += 8;
-			if (counter % 2 == 0) counter -= 1;
-			break;
-	}
-
-	return counterBytes43[(counter % 16) / 2];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte49(uint8_t counter)
-{
-	counter += 47;
-	return counterBytes64[(counter / 16)];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte50(uint8_t counter)
-{
-	counter -= 4;
-	return counterBytes65[counter % 8];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte51(uint8_t counter)
-{
-	counter -= 1;
-	return counterBytes66[(counter % 16) / 8];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte64(uint8_t counter)
-{
-	counter += 3;	
-	return counterBytes64[counter / 16];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte65(uint8_t counter)
-{
-	return counterBytes65[counter % 8];
-}
-
-uint8_t IthoCC1101::calculateMessage2Byte66(uint8_t counter)
-{
-	counter -= 13;
-	return counterBytes66[(counter % 16) / 8];
+  switch (command)
+  {
+    case IthoFull:
+      return (uint8_t*)&ithoMessagePowerCommandBytes[0];
+    case IthoStandby:
+      return (uint8_t*)&ithoMessageStandByCommandBytes[0];
+    case IthoHigh:
+      return (uint8_t*)&ithoMessageHighCommandBytes[0];
+    case IthoMedium:
+      return (uint8_t*)&ithoMessageMediumCommandBytes[0];
+    case IthoLow:
+      return (uint8_t*)&ithoMessageLowCommandBytes[0];
+    case IthoTimer1:
+      return (uint8_t*)&ithoMessageTimer1CommandBytes[0];
+    case IthoTimer2:
+      return (uint8_t*)&ithoMessageTimer2CommandBytes[0];
+    case IthoTimer3:
+      return (uint8_t*)&ithoMessageTimer3CommandBytes[0];
+    case IthoJoin:
+      return (uint8_t*)&ithoMessageJoinCommandBytes[0];
+    case IthoLeave:
+      return (uint8_t*)&ithoMessageLeaveCommandBytes[0];
+    default:
+      return (uint8_t*)&ithoMessageLowCommandBytes[0];
+  }
 }
 
 /*
-uint8_t* IthoCC1101::getMessage1CommandBytes(IthoCommand command)
-{
-	switch (command)
-	{
-		case IthoHigh:
-			return (uint8_t*)&ithoMessage1HighCommandBytes[0];
-		case IthoMedium:
-			return (uint8_t*)&ithoMessage1MediumCommandBytes[0];
-		case IthoLow:
-			return (uint8_t*)&ithoMessage1LowCommandBytes[0];
-		case IthoTimer1:
-			return (uint8_t*)&ithoMessage1Timer1CommandBytes[0];
-		case IthoTimer2:
-			return (uint8_t*)&ithoMessage1Timer2CommandBytes[0];
-		case IthoTimer3:
-			return (uint8_t*)&ithoMessage1Timer3CommandBytes[0];
-		case IthoJoin:
-			return (uint8_t*)&ithoMessage1JoinCommandBytes[0];
-		case IthoLeave:
-			return (uint8_t*)&ithoMessage1LeaveCommandBytes[0];
-		default:
-			return 0;
-	}
-}
+   Counter2 is the decimal sum of all bytes in decoded form from
+   deviceType up to the last byte before counter2 subtracted
+   from zero.
 */
+uint8_t IthoCC1101::getCounter2(IthoPacket *itho, uint8_t len) {
 
-uint8_t* IthoCC1101::getMessage2CommandBytes(IthoCommand command)
-{
-	switch (command)
-	{
-		case IthoFull:
-			return (uint8_t*)&ithoMessage2PowerCommandBytes[0];
-		case IthoStandby:
-			return (uint8_t*)&ithoMessage2StandByCommandBytes[0];
-		case IthoHigh:
-			return (uint8_t*)&ithoMessage2HighCommandBytes[0];
-		case IthoMedium:
-			return (uint8_t*)&ithoMessage2MediumCommandBytes[0];
-		case IthoLow:
-			return (uint8_t*)&ithoMessage2LowCommandBytes[0];
-		case IthoTimer1:
-			return (uint8_t*)&ithoMessage2Timer1CommandBytes[0];
-		case IthoTimer2:
-			return (uint8_t*)&ithoMessage2Timer2CommandBytes[0];
-		case IthoTimer3:
-			return (uint8_t*)&ithoMessage2Timer3CommandBytes[0];
-		case IthoJoin:
-			return (uint8_t*)&ithoMessage2JoinCommandBytes[0];
-		case IthoLeave:
-			return (uint8_t*)&ithoMessage2LeaveCommandBytes[0];
-		default:
-			return (uint8_t*)&ithoMessage2LowCommandBytes[0];
-	}
+  uint8_t val = 0;
+
+  for (uint8_t i = 0; i < len; i++) {
+    val += itho->dataDecoded[i];
+  }
+
+  return 0 - val;
 }
 
-//lookup value in array
-uint8_t IthoCC1101::getCounterIndex(const uint8_t *arr, uint8_t length, uint8_t value)
-{
-	for (uint8_t i=0; i<length; i++)
-		if (arr[i] == value)
-			return i;
-	
-	//-1 should never be returned!
-	return -1;
+uint8_t IthoCC1101::messageEncode(IthoPacket *itho, CC1101Packet *packet) {
+
+  uint8_t lenOutbuf = 0;
+
+  if ((itho->length * 20) % 8 == 0) { //inData len fits niecly in out buffer length
+    lenOutbuf = itho->length * 2.5;
+  }
+  else { //is this an issue? inData last byte does not fill out buffer length, add 1 out byte extra, padding is done after encode
+    lenOutbuf = (uint8_t)(itho->length * 2.5) + 0, 5;
+  }
+
+  uint8_t out_bytecounter = 14;   //index of Outbuf, start at offset 14, first part of the message is set manually
+  uint8_t out_bitcounter = 0;     //bit position of current outbuf byte
+  uint8_t out_patterncounter = 0; //bit counter to add 1 0 bit pattern after every 8 bits
+  uint8_t bitSelect = 4;          //bit position of the inData byte (4 - 7, 0 - 3)
+  uint8_t out_shift = 7;          //bit shift inData bit in position of outbuf byte
+
+  //we need to zero the out buffer first cause we are using bitshifts
+  for (int i = out_bytecounter; i < sizeof(packet->data) / sizeof(packet->data[0]); i++) {
+    packet->data[i] = 0;
+  }
+
+  //Serial.println();
+  for (uint8_t dataByte = 0; dataByte < itho->length; dataByte++) {
+    for (uint8_t dataBit = 0; dataBit < 8; dataBit++) {                                     //process a full dataByte at a time resulting in 20 output bits (2.5 bytes) with the pattern 7x6x5x4x 10 3x2x1x0x 10 7x6x5x4x 10 3x2x1x0x 10 etc
+      if (out_bitcounter == 8) {                                                            //check if new byte is needed
+        out_bytecounter++;
+        out_bitcounter = 0;
+      }
+
+      if (out_patterncounter == 8) {                                                        //check if we have to start with a 1 0 pattern
+        out_patterncounter = 0;
+        packet->data[out_bytecounter] = packet->data[out_bytecounter] | 1 << out_shift;
+        out_shift--;
+        out_bitcounter++;
+        packet->data[out_bytecounter] = packet->data[out_bytecounter] | 0 << out_shift;
+        if (out_shift == 0) out_shift = 8;
+        out_shift--;
+        out_bitcounter++;
+      }
+
+      if (out_bitcounter == 8) {                                                            //check if new byte is needed
+        out_bytecounter++;
+        out_bitcounter = 0;
+      }
+
+      //set the even bit
+      uint8_t bit = (itho->dataDecoded[dataByte] & (1 << bitSelect)) >> bitSelect;          //select bit and shift to bit pos 0
+      bitSelect++;
+      if (bitSelect == 8) bitSelect = 0;
+
+      packet->data[out_bytecounter] = packet->data[out_bytecounter] | bit << out_shift;     //shift bit in corect pos of current outbuf byte
+      out_shift--;
+      out_bitcounter++;
+      out_patterncounter++;
+
+      //set the odd bit (inverse of even bit)
+      bit = ~bit & 0b00000001;
+      packet->data[out_bytecounter] = packet->data[out_bytecounter] | bit << out_shift;
+      if (out_shift == 0) out_shift = 8;
+      out_shift--;
+      out_bitcounter++;
+      out_patterncounter++;
+
+    }
+
+  }
+  if (out_bitcounter < 8) {                                                                   //add closing 1 0 pattern to fill last packet->data byte and ensure DC balance in the message
+    for (uint8_t i = out_bitcounter; i < 8; i += 2) {
+      packet->data[out_bytecounter] = packet->data[out_bytecounter] | 1 << out_shift;
+      out_shift--;
+      packet->data[out_bytecounter] = packet->data[out_bytecounter] | 0 << out_shift;
+      if (out_shift == 0) out_shift = 8;
+      out_shift--;
+    }
+  }
+  //
+  //  for (int i = 0; i < sizeof(itho->dataDecoded) / sizeof(itho->dataDecoded[0]); i++) {        //zero out data in dataDecoded buffer. FIXME: probably could use a better solution.
+  //    itho->dataDecoded[i] = 0;
+  //  }
+
+  return out_bytecounter;
+}
+
+
+void IthoCC1101::messageDecode(CC1101Packet *packet, IthoPacket *itho) {
+
+  itho->length = 0;
+  int lenInbuf = packet->length;
+  while (lenInbuf >= 5) {
+    lenInbuf -= 5;
+    itho->length += 2;
+  }
+  if (lenInbuf >= 3) {
+    itho->length++;
+  }
+
+  for (int i = 0; i < sizeof(itho->dataDecoded) / sizeof(itho->dataDecoded[0]); i++) {
+    itho->dataDecoded[i] = 0;
+  }
+
+  if (DEBUG == 2) {
+    char buf[32];
+    Serial.println();
+    Serial.print("inMessage length: "); Serial.print(packet->length); Serial.println(" bytes; inMessage bit pattern: ");
+    for (int i = 0; i < packet->length; i++) {
+      strcpy(buf, "");
+      sprintf(buf, BYTE_TO_BINARY_PATTERN, BYTE_TO_BINARY(packet->data[i]));
+      Serial.print(buf);
+    }
+    Serial.println();
+  }
+
+  uint8_t out_i = 0;                                  //byte index
+  uint8_t out_j = 4;                                  //bit index
+  uint8_t in_bitcounter = 0;                          //process per 10 input bits
+
+  for (int i = 0; i < packet->length; i++) {
+    for (int j = 7; j > -1; j--) {
+      if (in_bitcounter == 0 || in_bitcounter == 2 || in_bitcounter == 4 || in_bitcounter == 6) { //select input bits for output
+        uint8_t x = packet->data[i];   //select input byte
+        x = x >> j;             //select input bit
+        x = x & 0b00000001;
+        x = x << out_j;         //set value for output bit
+        itho->dataDecoded[out_i] = itho->dataDecoded[out_i] | x;
+        out_j += 1;             //next output bit
+        if (out_j > 7) out_j = 0;
+        if (out_j == 4) out_i += 1;
+      }
+      in_bitcounter += 1;     //continue cyling in groups of 10 bits
+      if (in_bitcounter > 9) in_bitcounter = 0;
+    }
+  }
+  itho->deviceType  = itho->dataDecoded[0];
+  itho->deviceId[0] = itho->dataDecoded[1];
+  itho->deviceId[1] = itho->dataDecoded[2];
+  itho->deviceId[2] = itho->dataDecoded[3];
 }
 
 uint8_t IthoCC1101::ReadRSSI()
@@ -971,33 +764,66 @@ uint8_t IthoCC1101::ReadRSSI()
     value = rssi / 2;
     value += 74;
   }
-  return(value);
+  return (value);
 }
 
 bool IthoCC1101::checkID(const uint8_t *id)
 {
-	for (uint8_t i=0; i<8;i++)
-		if (id[i] != inIthoPacket.deviceId2[i])
-			return false;
-	return true;
+  for (uint8_t i = 0; i < 3; i++)
+    if (id[i] != inIthoPacket.deviceId[i])
+      return false;
+  return true;
 }
 
 String IthoCC1101::getLastIDstr(bool ashex) {
-	String str;
-	for (uint8_t i=0; i<8;i++) {
-		if (ashex) str += String(inIthoPacket.deviceId2[i], HEX);
-		else str += String(inIthoPacket.deviceId2[i]);
-		if (i<7) str += ":";
-	}
-	return str;
+  String str;
+  for (uint8_t i = 0; i < 3; i++) {
+    if (ashex) str += String(inIthoPacket.deviceId[i], HEX);
+    else str += String(inIthoPacket.deviceId[i]);
+    if (i < 2) str += ",";
+  }
+  return str;
 }
 
-String IthoCC1101::getLastMessage2str(bool ashex) {
-    String str = "Length="+ String(inMessage2.length) + ".";
-    for (uint8_t i=0; i<inMessage2.length;i++) {
-        if (ashex) str += String(inMessage2.data[i], HEX);
-        else str += String(inMessage2.data[i]);
-		if (i<inMessage2.length-1) str += ":";
+int * IthoCC1101::getLastID() {
+  static int id[3];
+  for (uint8_t i = 0; i < 3; i++) {
+    id[i] = inIthoPacket.deviceId[i];
+  }
+  return id;
+}
+
+String IthoCC1101::getLastMessagestr(bool ashex) {
+  String str = "Length=" + String(inMessage.length) + ".";
+  for (uint8_t i = 0; i < inMessage.length; i++) {
+    if (ashex) str += String(inMessage.data[i], HEX);
+    else str += String(inMessage.data[i]);
+    if (i < inMessage.length - 1) str += ":";
+  }
+  return str;
+}
+
+String IthoCC1101::LastMessageDecoded() {
+
+  String str;
+  if (inIthoPacket.length > 11) {
+    str += "Device type?: " + String(inIthoPacket.deviceType);
+    str += " - Device ID: " + String(inIthoPacket.deviceId[0]) + "," + String(inIthoPacket.deviceId[1]) + "," + String(inIthoPacket.deviceId[2]);
+    str += " - CMD: ";
+    for (int i = 4; i < inIthoPacket.length; i++) {
+      str += String(inIthoPacket.dataDecoded[i]);
+      if (i < inIthoPacket.length - 1) str += ",";
     }
-    return str;
+
+  }
+  else {
+    for (uint8_t i = 0; i < inIthoPacket.length; i++) {
+      str += String(inIthoPacket.dataDecoded[i]);
+      if (i < inIthoPacket.length - 1) str += ",";
+    }
+
+  }
+  str += "\n";
+  return str;
+
 }

--- a/Master/Itho/IthoCC1101.cpp
+++ b/Master/Itho/IthoCC1101.cpp
@@ -29,7 +29,7 @@
 
 ////alternative sync byte pattern (filter much more non-itho messages out. Maybe too strict? Testing needed.
 //#define STARTBYTE 0 //relevant data starts 0 bytes after the sync pattern bytes 179/42/171/42
-//#define SYNC1 163 //byte11 = 179, byte13 = 171 with SYNC1 = 163, 179 and 171 differ only by 1 bit
+//#define SYNC1 187 //byte11 = 179, byte13 = 171 with SYNC1 = 163, 179 and 171 differ only by 1 bit
 //#define SYNC0 42
 //#define MDMCFG2 0x03 //32bit sync word / 30bit specific
 
@@ -73,46 +73,45 @@ void IthoCC1101::initSendMessage(uint8_t len)
 
   /*
     Configuration reverse engineered from remote print. The commands below are used by IthoDaalderop.
-
-    Base frequency		868.299866MHz
-    Channel				0
-    Channel spacing		199.951172kHz
-    Carrier frequency	868.299866MHz
-    Xtal frequency		26.000000MHz
-    Data rate			38.3835kBaud
-    Manchester			disabled
-    Modulation			2-FSK
-    Deviation			50.781250kHz
-    TX power			?
-    PA ramping			enabled
-    Whitening			disabled
+    Base frequency    868.299866MHz
+    Channel       0
+    Channel spacing   199.951172kHz
+    Carrier frequency 868.299866MHz
+    Xtal frequency    26.000000MHz
+    Data rate     38.3835kBaud
+    Manchester      disabled
+    Modulation      2-FSK
+    Deviation     50.781250kHz
+    TX power      ?
+    PA ramping      enabled
+    Whitening     disabled
   */
   writeCommand(CC1101_SRES);
   delayMicroseconds(1);
-  writeRegister(CC1101_IOCFG0 , 0x2E);		//High impedance (3-state)
-  writeRegister(CC1101_FREQ2 , 0x21);		//00100001	878MHz-927.8MHz
-  writeRegister(CC1101_FREQ1 , 0x65);		//01100101
-  writeRegister(CC1101_FREQ0 , 0x6A);		//01101010
-  writeRegister(CC1101_MDMCFG4 , 0x5A);	//difference compared to message1
-  writeRegister(CC1101_MDMCFG3 , 0x83);	//difference compared to message1
-  writeRegister(CC1101_MDMCFG2 , 0x00);	//00000000	2-FSK, no manchester encoding/decoding, no preamble/sync
-  writeRegister(CC1101_MDMCFG1 , 0x22);	//00100010
-  writeRegister(CC1101_MDMCFG0 , 0xF8);	//11111000
-  writeRegister(CC1101_CHANNR , 0x00);		//00000000
-  writeRegister(CC1101_DEVIATN , 0x50);	//difference compared to message1
-  writeRegister(CC1101_FREND0 , 0x17);		//00010111	use index 7 in PA table
-  writeRegister(CC1101_MCSM0 , 0x18);		//00011000	PO timeout Approx. 146�s - 171�s, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
-  writeRegister(CC1101_FSCAL3 , 0xA9);		//10101001
-  writeRegister(CC1101_FSCAL2 , 0x2A);		//00101010
-  writeRegister(CC1101_FSCAL1 , 0x00);		//00000000
-  writeRegister(CC1101_FSCAL0 , 0x11);		//00010001
-  writeRegister(CC1101_FSTEST , 0x59);		//01011001	For test only. Do not write to this register.
-  writeRegister(CC1101_TEST2 , 0x81);		//10000001	For test only. Do not write to this register.
-  writeRegister(CC1101_TEST1 , 0x35);		//00110101	For test only. Do not write to this register.
-  writeRegister(CC1101_TEST0 , 0x0B);		//00001011	For test only. Do not write to this register.
-  writeRegister(CC1101_PKTCTRL0 , 0x12);	//00010010	Enable infinite length packets, CRC disabled, Turn data whitening off, Serial Synchronous mode
-  writeRegister(CC1101_ADDR , 0x00);		//00000000
-  writeRegister(CC1101_PKTLEN , 0xFF);		//11111111	//Not used, no hardware packet handling
+  writeRegister(CC1101_IOCFG0 , 0x2E);    //High impedance (3-state)
+  writeRegister(CC1101_FREQ2 , 0x21);   //00100001  878MHz-927.8MHz
+  writeRegister(CC1101_FREQ1 , 0x65);   //01100101
+  writeRegister(CC1101_FREQ0 , 0x6A);   //01101010
+  writeRegister(CC1101_MDMCFG4 , 0x5A); //difference compared to message1
+  writeRegister(CC1101_MDMCFG3 , 0x83); //difference compared to message1
+  writeRegister(CC1101_MDMCFG2 , 0x00); //00000000  2-FSK, no manchester encoding/decoding, no preamble/sync
+  writeRegister(CC1101_MDMCFG1 , 0x22); //00100010
+  writeRegister(CC1101_MDMCFG0 , 0xF8); //11111000
+  writeRegister(CC1101_CHANNR , 0x00);    //00000000
+  writeRegister(CC1101_DEVIATN , 0x50); //difference compared to message1
+  writeRegister(CC1101_FREND0 , 0x17);    //00010111  use index 7 in PA table
+  writeRegister(CC1101_MCSM0 , 0x18);   //00011000  PO timeout Approx. 146microseconds - 171microseconds, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
+  writeRegister(CC1101_FSCAL3 , 0xA9);    //10101001
+  writeRegister(CC1101_FSCAL2 , 0x2A);    //00101010
+  writeRegister(CC1101_FSCAL1 , 0x00);    //00000000
+  writeRegister(CC1101_FSCAL0 , 0x11);    //00010001
+  writeRegister(CC1101_FSTEST , 0x59);    //01011001  For test only. Do not write to this register.
+  writeRegister(CC1101_TEST2 , 0x81);   //10000001  For test only. Do not write to this register.
+  writeRegister(CC1101_TEST1 , 0x35);   //00110101  For test only. Do not write to this register.
+  writeRegister(CC1101_TEST0 , 0x0B);   //00001011  For test only. Do not write to this register.
+  writeRegister(CC1101_PKTCTRL0 , 0x12);  //00010010  Enable infinite length packets, CRC disabled, Turn data whitening off, Serial Synchronous mode
+  writeRegister(CC1101_ADDR , 0x00);    //00000000
+  writeRegister(CC1101_PKTLEN , 0xFF);    //11111111  //Not used, no hardware packet handling
 
   //0x6F,0x26,0x2E,0x8C,0x87,0xCD,0xC7,0xC0
   writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, (uint8_t*)ithoPaTableSend, 8);
@@ -121,20 +120,20 @@ void IthoCC1101::initSendMessage(uint8_t len)
   writeCommand(CC1101_SIDLE);
   writeCommand(CC1101_SIDLE);
 
-  writeRegister(CC1101_MDMCFG4 , 0x5A);	//difference compared to message1
-  writeRegister(CC1101_MDMCFG3 , 0x83);	//difference compared to message1
-  writeRegister(CC1101_DEVIATN , 0x50);	//difference compared to message1
-  writeRegister(CC1101_IOCFG0 , 0x2D);		//GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
-  writeRegister(CC1101_IOCFG1 , 0x0B);		//Serial Clock. Synchronous to the data in synchronous serial mode.
+  writeRegister(CC1101_MDMCFG4 , 0x5A); //difference compared to message1
+  writeRegister(CC1101_MDMCFG3 , 0x83); //difference compared to message1
+  writeRegister(CC1101_DEVIATN , 0x50); //difference compared to message1
+  writeRegister(CC1101_IOCFG0 , 0x2D);    //GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
+  writeRegister(CC1101_IOCFG1 , 0x0B);    //Serial Clock. Synchronous to the data in synchronous serial mode.
 
   writeCommand(CC1101_STX);
   writeCommand(CC1101_SIDLE);
 
-  writeRegister(CC1101_MDMCFG4 , 0x5A);	//difference compared to message1
-  writeRegister(CC1101_MDMCFG3 , 0x83);	//difference compared to message1
-  writeRegister(CC1101_DEVIATN , 0x50);	//difference compared to message1
-  //writeRegister(CC1101_IOCFG0 ,0x2D);		//GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
-  //writeRegister(CC1101_IOCFG1 ,0x0B);		//Serial Clock. Synchronous to the data in synchronous serial mode.
+  writeRegister(CC1101_MDMCFG4 , 0x5A); //difference compared to message1
+  writeRegister(CC1101_MDMCFG3 , 0x83); //difference compared to message1
+  writeRegister(CC1101_DEVIATN , 0x50); //difference compared to message1
+  //writeRegister(CC1101_IOCFG0 ,0x2D);   //GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
+  //writeRegister(CC1101_IOCFG1 ,0x0B);   //Serial Clock. Synchronous to the data in synchronous serial mode.
 
   //Itho is using serial mode for transmit. We want to use the TX FIFO with fixed packet length for simplicity.
   writeRegister(CC1101_IOCFG0 , 0x2E);
@@ -163,19 +162,19 @@ void IthoCC1101::initReceive()
   /*
     Configuration reverse engineered from RFT print.
 
-    Base frequency		868.299866MHz
-    Channel				0
-    Channel spacing		199.951172kHz
-    Carrier frequency	868.299866MHz
-    Xtal frequency		26.000000MHz
-    Data rate			38.3835kBaud
-    RX filter BW		325.000000kHz
-    Manchester			disabled
-    Modulation			2-FSK
-    Deviation			50.781250kHz
-    TX power			0x6F,0x26,0x2E,0x7F,0x8A,0x84,0xCA,0xC4
-    PA ramping			enabled
-    Whitening			disabled
+    Base frequency    868.299866MHz
+    Channel       0
+    Channel spacing   199.951172kHz
+    Carrier frequency 868.299866MHz
+    Xtal frequency    26.000000MHz
+    Data rate     38.3835kBaud
+    RX filter BW    325.000000kHz
+    Manchester      disabled
+    Modulation      2-FSK
+    Deviation     50.781250kHz
+    TX power      0x6F,0x26,0x2E,0x7F,0x8A,0x84,0xCA,0xC4
+    PA ramping      enabled
+    Whitening     disabled
   */
   writeCommand(CC1101_SRES);
 
@@ -191,24 +190,24 @@ void IthoCC1101::initReceive()
   while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE) yield();
 
   writeRegister(CC1101_FSCAL2 , 0x00);
-  writeRegister(CC1101_MCSM0 , 0x18);			//no auto calibrate
+  writeRegister(CC1101_MCSM0 , 0x18);     //no auto calibrate
   writeRegister(CC1101_FREQ2 , 0x21);
   writeRegister(CC1101_FREQ1 , 0x65);
   writeRegister(CC1101_FREQ0 , 0x6A);
-  writeRegister(CC1101_IOCFG0 , 0x2E);			//High impedance (3-state)
-  writeRegister(CC1101_IOCFG2 , 0x06);			//0x06 Assert when sync word has been sent / received, and de-asserts at the end of the packet.
+  writeRegister(CC1101_IOCFG0 , 0x2E);      //High impedance (3-state)
+  writeRegister(CC1101_IOCFG2 , 0x06);      //0x06 Assert when sync word has been sent / received, and de-asserts at the end of the packet.
   writeRegister(CC1101_FSCTRL1 , 0x06);
   writeRegister(CC1101_FSCTRL0 , 0x00);
   writeRegister(CC1101_MDMCFG4 , 0x5A);
   writeRegister(CC1101_MDMCFG3 , 0x83);
-  writeRegister(CC1101_MDMCFG2 , 0x00);		//Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
-  writeRegister(CC1101_MDMCFG1 , 0x22);		//Disable FEC
+  writeRegister(CC1101_MDMCFG2 , 0x00);   //Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
+  writeRegister(CC1101_MDMCFG1 , 0x22);   //Disable FEC
   writeRegister(CC1101_MDMCFG0 , 0xF8);
   writeRegister(CC1101_CHANNR , 0x00);
   writeRegister(CC1101_DEVIATN , 0x50);
   writeRegister(CC1101_FREND1 , 0x56);
   writeRegister(CC1101_FREND0 , 0x17);
-  writeRegister(CC1101_MCSM0 , 0x18);			//no auto calibrate
+  writeRegister(CC1101_MCSM0 , 0x18);     //no auto calibrate
   writeRegister(CC1101_FOCCFG , 0x16);
   writeRegister(CC1101_BSCFG , 0x6C);
   writeRegister(CC1101_AGCCTRL2 , 0x43);
@@ -222,8 +221,8 @@ void IthoCC1101::initReceive()
   writeRegister(CC1101_TEST2 , 0x81);
   writeRegister(CC1101_TEST1 , 0x35);
   writeRegister(CC1101_TEST0 , 0x0B);
-  writeRegister(CC1101_PKTCTRL1 , 0x04);		//No address check, Append two bytes with status RSSI/LQI/CRC OK,
-  writeRegister(CC1101_PKTCTRL0 , 0x32);		//Infinite packet length mode, CRC disabled for TX and RX, No data whitening, Asynchronous serial mode, Data in on GDO0 and data out on either of the GDOx pins
+  writeRegister(CC1101_PKTCTRL1 , 0x04);    //No address check, Append two bytes with status RSSI/LQI/CRC OK,
+  writeRegister(CC1101_PKTCTRL0 , 0x32);    //Infinite packet length mode, CRC disabled for TX and RX, No data whitening, Asynchronous serial mode, Data in on GDO0 and data out on either of the GDOx pins
   writeRegister(CC1101_ADDR , 0x00);
   writeRegister(CC1101_PKTLEN , 0xFF);
   writeRegister(CC1101_TEST0 , 0x09);
@@ -233,13 +232,13 @@ void IthoCC1101::initReceive()
   //wait for calibration to finish
   while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE) yield();
 
-  writeRegister(CC1101_MCSM0 , 0x18);			//no auto calibrate
+  writeRegister(CC1101_MCSM0 , 0x18);     //no auto calibrate
 
   writeCommand(CC1101_SIDLE);
   writeCommand(CC1101_SIDLE);
 
-  writeRegister(CC1101_MDMCFG2 , 0x00);		//Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
-  writeRegister(CC1101_IOCFG0 , 0x0D);			//Serial Data Output. Used for asynchronous serial mode.
+  writeRegister(CC1101_MDMCFG2 , 0x00);   //Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
+  writeRegister(CC1101_IOCFG0 , 0x0D);      //Serial Data Output. Used for asynchronous serial mode.
 
   writeCommand(CC1101_SRX);
 
@@ -252,7 +251,7 @@ void  IthoCC1101::initReceiveMessage()
 {
   uint8_t marcState;
 
-  writeCommand(CC1101_SIDLE);	//idle
+  writeCommand(CC1101_SIDLE); //idle
 
   //set datarate
   writeRegister(CC1101_MDMCFG4 , 0x5A); // set kBaud
@@ -260,13 +259,13 @@ void  IthoCC1101::initReceiveMessage()
   writeRegister(CC1101_DEVIATN , 0x50);
 
   //set fifo mode with fixed packet length and sync bytes
-  writeRegister(CC1101_PKTLEN , 63);			//63 bytes message (sync at beginning of message is removed by CC1101)
+  writeRegister(CC1101_PKTLEN , 63);      //63 bytes message (sync at beginning of message is removed by CC1101)
 
   //set fifo mode with fixed packet length and sync bytes
   writeRegister(CC1101_PKTCTRL0 , 0x00);
-  writeRegister(CC1101_SYNC1 , 163);			//message2 byte11 = 179, byte13 = 171 with SYNC1 = 163, 179 and 171 differ only by 1 bit
-  writeRegister(CC1101_SYNC0 , 42);			  //message2 byte12,14
-  writeRegister(CC1101_MDMCFG2 , 0x03);   //32bit sync word / 30bit specific
+  writeRegister(CC1101_SYNC1 , SYNC1);
+  writeRegister(CC1101_SYNC0 , SYNC0);
+  writeRegister(CC1101_MDMCFG2 , MDMCFG2);
   writeRegister(CC1101_PKTCTRL1 , 0x00);
 
   writeCommand(CC1101_SRX); //switch to RX state
@@ -291,10 +290,17 @@ bool IthoCC1101::parseMessageCommand() {
 
   messageDecode(&inMessage, &inIthoPacket);
 
+  //deviceType of message type?
+  inIthoPacket.deviceType  = inIthoPacket.dataDecoded[0];
+
+  //deviceID
+  inIthoPacket.deviceId[0] = inIthoPacket.dataDecoded[1];
+  inIthoPacket.deviceId[1] = inIthoPacket.dataDecoded[2];
+  inIthoPacket.deviceId[2] = inIthoPacket.dataDecoded[3];
+  
   //counter1
   inIthoPacket.counter = inIthoPacket.dataDecoded[4];
 
-  bool isPowerCommand     = checkIthoCommand(&inIthoPacket, ithoMessagePowerCommandBytes);
   bool isHighCommand      = checkIthoCommand(&inIthoPacket, ithoMessageHighCommandBytes);
   bool isRVHighCommand    = checkIthoCommand(&inIthoPacket, ithoMessageRVHighCommandBytes);
   bool isMediumCommand    = checkIthoCommand(&inIthoPacket, ithoMessageMediumCommandBytes);
@@ -313,7 +319,6 @@ bool IthoCC1101::parseMessageCommand() {
 
   //determine command
   inIthoPacket.command = IthoUnknown;
-  if (isPowerCommand)    inIthoPacket.command = IthoFull;
   if (isHighCommand)     inIthoPacket.command = IthoHigh;
   if (isRVHighCommand)   inIthoPacket.command = IthoHigh;
   if (isMediumCommand)   inIthoPacket.command = IthoMedium;
@@ -356,9 +361,9 @@ bool IthoCC1101::parseMessageCommand() {
 bool IthoCC1101::checkIthoCommand(IthoPacket *itho, const uint8_t commandBytes[]) {
   uint8_t offset = 0;
   if (itho->deviceType == 28 || itho->deviceType == 24) offset = 2;
-  for (int i = 0; i < 6; i++)
+  for (int i = 4; i < 6; i++)
   {
-    if (i == 2) continue; //skip byte3, rft-rv device seem to sometimes have a different number there for Timer command
+    //if (i == 2 || i == 3) continue; //skip byte3 and byte4, rft-rv and co2-auto remote device seem to sometimes have a different number there
     if ( (itho->dataDecoded[i + 5 + offset] != commandBytes[i]) && (itho->dataDecodedChk[i + 5 + offset] != commandBytes[i]) ) {
       return false;
     }
@@ -393,18 +398,6 @@ void IthoCC1101::sendCommand(IthoCommand command)
     default:
       createMessageCommand(&outIthoPacket, &outMessage);
       break;
-  }
-
-  if (DEBUG == 2) {
-    char buf[32];
-    Serial.println();
-    Serial.print("outMessage length: "); Serial.print(outMessage.length); Serial.println(" bytes; outMessage bit pattern: ");
-    for (int i = 0; i < outMessage.length; i++) {
-      strcpy(buf, "");
-      sprintf(buf, BYTE_TO_BINARY_PATTERN, BYTE_TO_BINARY(outMessage.data[i]));
-      Serial.print(buf);
-    }
-    Serial.println();
   }
 
   //send messages
@@ -593,8 +586,6 @@ uint8_t* IthoCC1101::getMessageCommandBytes(IthoCommand command)
 {
   switch (command)
   {
-    case IthoFull:
-      return (uint8_t*)&ithoMessagePowerCommandBytes[0];
     case IthoStandby:
       return (uint8_t*)&ithoMessageStandByCommandBytes[0];
     case IthoHigh:
@@ -710,20 +701,16 @@ uint8_t IthoCC1101::messageEncode(IthoPacket *itho, CC1101Packet *packet) {
       out_shift--;
     }
   }
-  //
-  //  for (int i = 0; i < sizeof(itho->dataDecoded) / sizeof(itho->dataDecoded[0]); i++) {        //zero out data in dataDecoded buffer. FIXME: probably could use a better solution.
-  //    itho->dataDecoded[i] = 0;
-  //  }
 
   return out_bytecounter;
 }
 
 
 void IthoCC1101::messageDecode(CC1101Packet *packet, IthoPacket *itho) {
-
+  
   itho->length = 0;
   int lenInbuf = packet->length;
-  
+
   lenInbuf -= STARTBYTE; //correct for sync byte pos
   
   while (lenInbuf >= 5) {
@@ -776,10 +763,7 @@ void IthoCC1101::messageDecode(CC1101Packet *packet, IthoPacket *itho) {
       in_bitcounter += 1;     //continue cyling in groups of 10 bits
       if (in_bitcounter > 9) in_bitcounter = 0;
     }
-  }  itho->deviceType  = itho->dataDecoded[0];
-  itho->deviceId[0] = itho->dataDecoded[1];
-  itho->deviceId[1] = itho->dataDecoded[2];
-  itho->deviceId[2] = itho->dataDecoded[3];
+  }
 }
 
 uint8_t IthoCC1101::ReadRSSI()
@@ -844,7 +828,6 @@ String IthoCC1101::LastMessageDecoded() {
   String str;
   if (inIthoPacket.length > 11) {
     str += "Device type?: " + String(inIthoPacket.deviceType);
-    str += " - Device ID: " + String(inIthoPacket.deviceId[0]) + "," + String(inIthoPacket.deviceId[1]) + "," + String(inIthoPacket.deviceId[2]);
     str += " - CMD: ";
     for (int i = 4; i < inIthoPacket.length; i++) {
       str += String(inIthoPacket.dataDecoded[i]);

--- a/Master/Itho/IthoCC1101.cpp
+++ b/Master/Itho/IthoCC1101.cpp
@@ -259,20 +259,15 @@ void  IthoCC1101::initReceiveMessage()
   }
 }
 
-bool IthoCC1101::checkForNewPacket()
-{
-  if (receiveData(&inMessage, 63))
-  {
-    parseMessageCommand();
+bool IthoCC1101::checkForNewPacket() {
+  if (receiveData(&inMessage, 63) && parseMessageCommand()) {
     initReceiveMessage();
     return true;
   }
-
   return false;
 }
 
-void IthoCC1101::parseMessageCommand()
-{
+bool IthoCC1101::parseMessageCommand() {
   bool isPowerCommand = true;
   bool isHighCommand = true;
   bool isRVHighCommand = true;
@@ -337,6 +332,27 @@ void IthoCC1101::parseMessageCommand()
   if (isJoin2Command)    inIthoPacket.command = IthoJoin;
   if (isRVJoinCommand)   inIthoPacket.command = IthoJoin;
   if (isLeaveCommand)    inIthoPacket.command = IthoLeave;
+  
+
+  uint8_t mLen = 0;
+  if (isPowerCommand || isHighCommand || isMediumCommand || isLowCommand || isStandByCommand || isTimer1Command || isTimer2Command || isTimer3Command) {
+    mLen = 11;
+  }
+  else if (isJoinCommand || isJoin2Command) {
+    mLen = 20;
+  }
+  else if (isLeaveCommand) {
+    mLen = 14;
+  }
+  else {
+    return true;
+  }
+  if (getCounter2(&inIthoPacket, mLen) != inIthoPacket.dataDecoded[mLen]) {
+    inIthoPacket.command = IthoUnknown;
+    return false;
+  }
+  
+  return true;
 }
 
 void IthoCC1101::sendCommand(IthoCommand command)

--- a/Master/Itho/IthoCC1101.cpp
+++ b/Master/Itho/IthoCC1101.cpp
@@ -590,6 +590,8 @@ uint8_t* IthoCC1101::getMessageCommandBytes(IthoCommand command)
       return (uint8_t*)&ithoMessageStandByCommandBytes[0];
     case IthoHigh:
       return (uint8_t*)&ithoMessageHighCommandBytes[0];
+    case IthoFull:
+      return (uint8_t*)&ithoMessageFullCommandBytes[0];
     case IthoMedium:
       return (uint8_t*)&ithoMessageMediumCommandBytes[0];
     case IthoLow:
@@ -633,7 +635,7 @@ uint8_t IthoCC1101::messageEncode(IthoPacket *itho, CC1101Packet *packet) {
     lenOutbuf = itho->length * 2.5;
   }
   else { //is this an issue? inData last byte does not fill out buffer length, add 1 out byte extra, padding is done after encode
-    lenOutbuf = (uint8_t)(itho->length * 2.5) + 0, 5;
+    lenOutbuf = (uint8_t)(itho->length * 2.5) + 0.5;
   }
 
   uint8_t out_bytecounter = 14;   //index of Outbuf, start at offset 14, first part of the message is set manually

--- a/Master/Itho/IthoCC1101.cpp
+++ b/Master/Itho/IthoCC1101.cpp
@@ -1,23 +1,10 @@
 /*
    Author: Klusjesman, supersjimmie, modified and reworked by arjenhiemstra
 */
-#define DEBUG 0
-
-//printf("Leading text "BYTE_TO_BINARY_PATTERN, BYTE_TO_BINARY(byte));
-#define BYTE_TO_BINARY_PATTERN "%c,%c,%c,%c,%c,%c,%c,%c,"
-#define BYTE_TO_BINARY(byte)  \
-  (byte & 0x80 ? '1' : '0'), \
-  (byte & 0x40 ? '1' : '0'), \
-  (byte & 0x20 ? '1' : '0'), \
-  (byte & 0x10 ? '1' : '0'), \
-  (byte & 0x08 ? '1' : '0'), \
-  (byte & 0x04 ? '1' : '0'), \
-  (byte & 0x02 ? '1' : '0'), \
-  (byte & 0x01 ? '1' : '0')
 
 #include "IthoCC1101.h"
 #include "IthoPacket.h"
-#include <string.h>
+#include <string>
 #include <Arduino.h>
 #include <SPI.h>
 
@@ -29,17 +16,23 @@
 //#define SYNC0 171
 //#define MDMCFG2 0x02 //16bit sync word / 16bit specific
 
-//alternative sync byte pattern (filter much more non-itho messages out. Maybe too strict? Testing needed.
-#define STARTBYTE 0 //relevant data starts 0 bytes after the sync pattern bytes 179/42/171/42
-#define SYNC1 187 //byte11 = 179, byte13 = 171 with SYNC1 = 163, 179 and 171 differ only by 1 bit
+// alternative sync byte pattern (filter much more non-itho messages out. Maybe too strict? Testing needed.
+#define STARTBYTE 0 // relevant data starts 0 bytes after the sync pattern bytes 179/42/171/42
+#define SYNC1 187   // byte11 = 179, byte13 = 171 with SYNC1 = 187, 179 and 171 differ only by 1 bit
 #define SYNC0 42
-#define MDMCFG2 0x03 //32bit sync word / 30bit specific
+#define MDMCFG2 0x03 // 32bit sync word / 30bit specific
 
-//alternative sync byte pattern
+// alternative sync byte pattern
 //#define STARTBYTE 2 //relevant data starts 2 bytes after the sync pattern bytes 179/42
 //#define SYNC1 179
 //#define SYNC0 42
 //#define MDMCFG2 0x02 //16bit sync word / 16bit specific
+
+// alternative sync byte pattern
+//#define STARTBYTE 1 //relevant data starts 1 byte after the sync pattern bytes 89/149/85/149
+//#define SYNC1 93 //byte11 = 89, byte13 = 85 with SYNC1 = 94, 89 and 85 differ only by 1 bit and line up with the start bit
+//#define SYNC0 149
+//#define MDMCFG2 0x03 //32bit sync word / 30bit specific
 
 // default constructor
 IthoCC1101::IthoCC1101(uint8_t counter, uint8_t sendTries) : CC1101()
@@ -60,9 +53,7 @@ IthoCC1101::IthoCC1101(uint8_t counter, uint8_t sendTries) : CC1101()
   bindAllowed = false;
   allowAll = true;
 
-
-
-} //IthoCC1101
+} // IthoCC1101
 
 // default destructor
 IthoCC1101::~IthoCC1101()
@@ -71,12 +62,12 @@ IthoCC1101::~IthoCC1101()
 
 void IthoCC1101::initSendMessage(uint8_t len)
 {
-  //finishTransfer();
+  // finishTransfer();
   writeCommand(CC1101_SIDLE);
   delayMicroseconds(1);
-  writeRegister(CC1101_IOCFG0 , 0x2E);
+  writeRegister(CC1101_IOCFG0, 0x2E);
   delayMicroseconds(1);
-  writeRegister(CC1101_IOCFG1 , 0x2E);
+  writeRegister(CC1101_IOCFG1, 0x2E);
   delayMicroseconds(1);
   writeCommand(CC1101_SIDLE);
   writeCommand(CC1101_SPWD);
@@ -99,61 +90,60 @@ void IthoCC1101::initSendMessage(uint8_t len)
   */
   writeCommand(CC1101_SRES);
   delayMicroseconds(1);
-  writeRegister(CC1101_IOCFG0 , 0x2E);    //High impedance (3-state)
-  writeRegister(CC1101_FREQ2 , cc_freq[2]);   //00100001  878MHz-927.8MHz
-  writeRegister(CC1101_FREQ1 , cc_freq[1]);   //01100101
-  writeRegister(CC1101_FREQ0 , cc_freq[0]);   //01101010
-  writeRegister(CC1101_MDMCFG4 , 0x5A); //difference compared to message1
-  writeRegister(CC1101_MDMCFG3 , 0x83); //difference compared to message1
-  writeRegister(CC1101_MDMCFG2 , 0x00); //00000000  2-FSK, no manchester encoding/decoding, no preamble/sync
-  writeRegister(CC1101_MDMCFG1 , 0x22); //00100010
-  writeRegister(CC1101_MDMCFG0 , 0xF8); //11111000
-  writeRegister(CC1101_CHANNR , 0x00);    //00000000
-  writeRegister(CC1101_DEVIATN , 0x50); //difference compared to message1
-  writeRegister(CC1101_FREND0 , 0x17);    //00010111  use index 7 in PA table
-  writeRegister(CC1101_MCSM0 , 0x18);   //00011000  PO timeout Approx. 146microseconds - 171microseconds, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
-  writeRegister(CC1101_FSCAL3 , 0xA9);    //10101001
-  writeRegister(CC1101_FSCAL2 , 0x2A);    //00101010
-  writeRegister(CC1101_FSCAL1 , 0x00);    //00000000
-  writeRegister(CC1101_FSCAL0 , 0x11);    //00010001
-  writeRegister(CC1101_FSTEST , 0x59);    //01011001  For test only. Do not write to this register.
-  writeRegister(CC1101_TEST2 , 0x81);   //10000001  For test only. Do not write to this register.
-  writeRegister(CC1101_TEST1 , 0x35);   //00110101  For test only. Do not write to this register.
-  writeRegister(CC1101_TEST0 , 0x0B);   //00001011  For test only. Do not write to this register.
-  writeRegister(CC1101_PKTCTRL0 , 0x12);  //00010010  Enable infinite length packets, CRC disabled, Turn data whitening off, Serial Synchronous mode
-  writeRegister(CC1101_ADDR , 0x00);    //00000000
-  writeRegister(CC1101_PKTLEN , 0xFF);    //11111111  //Not used, no hardware packet handling
+  writeRegister(CC1101_IOCFG0, 0x2E);      // High impedance (3-state)
+  writeRegister(CC1101_FREQ2, cc_freq[2]); // 00100001  878MHz-927.8MHz
+  writeRegister(CC1101_FREQ1, cc_freq[1]); // 01100101
+  writeRegister(CC1101_FREQ0, cc_freq[0]); // 01101010
+  writeRegister(CC1101_MDMCFG4, 0x5A);     // difference compared to message1
+  writeRegister(CC1101_MDMCFG3, 0x83);     // difference compared to message1
+  writeRegister(CC1101_MDMCFG2, 0x00);     // 00000000  2-FSK, no manchester encoding/decoding, no preamble/sync
+  writeRegister(CC1101_MDMCFG1, 0x22);     // 00100010
+  writeRegister(CC1101_MDMCFG0, 0xF8);     // 11111000
+  writeRegister(CC1101_CHANNR, 0x00);      // 00000000
+  writeRegister(CC1101_DEVIATN, 0x50);     // difference compared to message1
+  writeRegister(CC1101_FREND0, 0x17);      // 00010111  use index 7 in PA table
+  writeRegister(CC1101_MCSM0, 0x18);       // 00011000  PO timeout Approx. 146microseconds - 171microseconds, Auto calibrate When going from IDLE to RX or TX (or FSTXON)
+  writeRegister(CC1101_FSCAL3, 0xA9);      // 10101001
+  writeRegister(CC1101_FSCAL2, 0x2A);      // 00101010
+  writeRegister(CC1101_FSCAL1, 0x00);      // 00000000
+  writeRegister(CC1101_FSCAL0, 0x11);      // 00010001
+  writeRegister(CC1101_FSTEST, 0x59);      // 01011001  For test only. Do not write to this register.
+  writeRegister(CC1101_TEST2, 0x81);       // 10000001  For test only. Do not write to this register.
+  writeRegister(CC1101_TEST1, 0x35);       // 00110101  For test only. Do not write to this register.
+  writeRegister(CC1101_TEST0, 0x0B);       // 00001011  For test only. Do not write to this register.
+  writeRegister(CC1101_PKTCTRL0, 0x12);    // 00010010  Enable infinite length packets, CRC disabled, Turn data whitening off, Serial Synchronous mode
+  writeRegister(CC1101_ADDR, 0x00);        // 00000000
+  writeRegister(CC1101_PKTLEN, 0xFF);      // 11111111  //Not used, no hardware packet handling
 
-  //0x6F,0x26,0x2E,0x8C,0x87,0xCD,0xC7,0xC0
-  writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, (uint8_t*)ithoPaTableSend, 8);
+  // 0x6F,0x26,0x2E,0x8C,0x87,0xCD,0xC7,0xC0
+  writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, ithoPaTableSend, 8);
 
-  //difference, message1 sends a STX here
+  // difference, message1 sends a STX here
   writeCommand(CC1101_SIDLE);
   writeCommand(CC1101_SIDLE);
 
-  writeRegister(CC1101_MDMCFG4 , 0x5A); //difference compared to message1
-  writeRegister(CC1101_MDMCFG3 , 0x83); //difference compared to message1
-  writeRegister(CC1101_DEVIATN , 0x50); //difference compared to message1
-  writeRegister(CC1101_IOCFG0 , 0x2D);    //GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
-  writeRegister(CC1101_IOCFG1 , 0x0B);    //Serial Clock. Synchronous to the data in synchronous serial mode.
+  writeRegister(CC1101_MDMCFG4, 0x5A); // difference compared to message1
+  writeRegister(CC1101_MDMCFG3, 0x83); // difference compared to message1
+  writeRegister(CC1101_DEVIATN, 0x50); // difference compared to message1
+  writeRegister(CC1101_IOCFG0, 0x2D);  // GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
+  writeRegister(CC1101_IOCFG1, 0x0B);  // Serial Clock. Synchronous to the data in synchronous serial mode.
 
   writeCommand(CC1101_STX);
   writeCommand(CC1101_SIDLE);
 
-  writeRegister(CC1101_MDMCFG4 , 0x5A); //difference compared to message1
-  writeRegister(CC1101_MDMCFG3 , 0x83); //difference compared to message1
-  writeRegister(CC1101_DEVIATN , 0x50); //difference compared to message1
-  //writeRegister(CC1101_IOCFG0 ,0x2D);   //GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
-  //writeRegister(CC1101_IOCFG1 ,0x0B);   //Serial Clock. Synchronous to the data in synchronous serial mode.
+  writeRegister(CC1101_MDMCFG4, 0x5A); // difference compared to message1
+  writeRegister(CC1101_MDMCFG3, 0x83); // difference compared to message1
+  writeRegister(CC1101_DEVIATN, 0x50); // difference compared to message1
+  // writeRegister(CC1101_IOCFG0 ,0x2D);   //GDO0_Z_EN_N. When this output is 0, GDO0 is configured as input (for serial TX data).
+  // writeRegister(CC1101_IOCFG1 ,0x0B);   //Serial Clock. Synchronous to the data in synchronous serial mode.
 
-  //Itho is using serial mode for transmit. We want to use the TX FIFO with fixed packet length for simplicity.
-  writeRegister(CC1101_IOCFG0 , 0x2E);
-  writeRegister(CC1101_IOCFG1 , 0x2E);
-  writeRegister(CC1101_PKTCTRL0 , 0x00);
-  writeRegister(CC1101_PKTCTRL1 , 0x00);
+  // Itho is using serial mode for transmit. We want to use the TX FIFO with fixed packet length for simplicity.
+  writeRegister(CC1101_IOCFG0, 0x2E);
+  writeRegister(CC1101_IOCFG1, 0x2E);
+  writeRegister(CC1101_PKTCTRL0, 0x00);
+  writeRegister(CC1101_PKTCTRL1, 0x00);
 
-  writeRegister(CC1101_PKTLEN , len);
-
+  writeRegister(CC1101_PKTLEN, len);
 }
 
 void IthoCC1101::finishTransfer()
@@ -161,8 +151,8 @@ void IthoCC1101::finishTransfer()
   writeCommand(CC1101_SIDLE);
   delayMicroseconds(1);
 
-  writeRegister(CC1101_IOCFG0 , 0x2E);
-  writeRegister(CC1101_IOCFG1 , 0x2E);
+  writeRegister(CC1101_IOCFG0, 0x2E);
+  writeRegister(CC1101_IOCFG1, 0x2E);
 
   writeCommand(CC1101_SIDLE);
   writeCommand(CC1101_SPWD);
@@ -189,139 +179,146 @@ void IthoCC1101::initReceive()
   */
   writeCommand(CC1101_SRES);
 
-  writeRegister(CC1101_TEST0 , 0x09);
-  writeRegister(CC1101_FSCAL2 , 0x00);
+  writeRegister(CC1101_TEST0, 0x09);
+  writeRegister(CC1101_FSCAL2, 0x00);
 
-  //0x6F,0x26,0x2E,0x7F,0x8A,0x84,0xCA,0xC4
-  writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, (uint8_t*)ithoPaTableReceive, 8);
-
-  writeCommand(CC1101_SCAL);
-
-  //wait for calibration to finish
-  while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE) yield();
-
-  writeRegister(CC1101_FSCAL2 , 0x00);
-  writeRegister(CC1101_MCSM0 , 0x18);     //no auto calibrate
-  writeRegister(CC1101_FREQ2 , cc_freq[2]);
-  writeRegister(CC1101_FREQ1 , cc_freq[1]);
-  writeRegister(CC1101_FREQ0 , cc_freq[0]);
-  writeRegister(CC1101_IOCFG0 , 0x2E);      //High impedance (3-state)
-  writeRegister(CC1101_IOCFG2 , 0x06);      //0x06 Assert when sync word has been sent / received, and de-asserts at the end of the packet.
-  writeRegister(CC1101_FSCTRL1 , 0x0F); //change 06
-  writeRegister(CC1101_FSCTRL0 , 0x00);
-  writeRegister(CC1101_MDMCFG4 , 0x6A);
-  writeRegister(CC1101_MDMCFG3 , 0x83);
-  writeRegister(CC1101_MDMCFG2 , 0x10);   //Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
-  writeRegister(CC1101_MDMCFG1 , 0x22);   //Disable FEC
-  writeRegister(CC1101_MDMCFG0 , 0xF8);
-  writeRegister(CC1101_CHANNR , 0x00);
-  writeRegister(CC1101_DEVIATN , 0x50);
-  writeRegister(CC1101_FREND1 , 0x56);
-  writeRegister(CC1101_FREND0 , 0x10);
-  writeRegister(CC1101_MCSM0 , 0x18);     //no auto calibrate
-  writeRegister(CC1101_FOCCFG , 0x16);
-  writeRegister(CC1101_BSCFG , 0x6C);
-  writeRegister(CC1101_AGCCTRL2 , 0x43);
-  writeRegister(CC1101_AGCCTRL1 , 0x40);
-  writeRegister(CC1101_AGCCTRL0 , 0x91);
-  writeRegister(CC1101_FSCAL3 , 0xE9);
-  writeRegister(CC1101_FSCAL2 , 0x21);
-  writeRegister(CC1101_FSCAL1 , 0x00);
-  writeRegister(CC1101_FSCAL0 , 0x1F);
-  writeRegister(CC1101_FSTEST , 0x59);
-  writeRegister(CC1101_TEST2 , 0x81);
-  writeRegister(CC1101_TEST1 , 0x35);
-  writeRegister(CC1101_TEST0 , 0x09);
-  writeRegister(CC1101_PKTCTRL1 , 0x04);    //No address check, Append two bytes with status RSSI/LQI/CRC OK,
-  writeRegister(CC1101_PKTCTRL0 , 0x32);    //Infinite packet length mode, CRC disabled for TX and RX, No data whitening, Asynchronous serial mode, Data in on GDO0 and data out on either of the GDOx pins
-  writeRegister(CC1101_ADDR , 0x00);
-  writeRegister(CC1101_PKTLEN , 0xFF);
-
+  // 0x6F,0x26,0x2E,0x7F,0x8A,0x84,0xCA,0xC4
+  writeBurstRegister(CC1101_PATABLE | CC1101_WRITE_BURST, ithoPaTableReceive, 8);
 
   writeCommand(CC1101_SCAL);
 
-  //wait for calibration to finish
-  while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE) yield();
+  // wait for calibration to finish
+  while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE)
+    yield();
 
-  writeRegister(CC1101_MCSM0 , 0x18);     //no auto calibrate
+  writeRegister(CC1101_FSCAL2, 0x00);
+  writeRegister(CC1101_MCSM0, 0x18); // no auto calibrate
+  writeRegister(CC1101_FREQ2, cc_freq[2]);
+  writeRegister(CC1101_FREQ1, cc_freq[1]);
+  writeRegister(CC1101_FREQ0, cc_freq[0]);
+  writeRegister(CC1101_IOCFG0, 0x2E);  // High impedance (3-state)
+  writeRegister(CC1101_IOCFG2, 0x06);  // 0x06 Assert when sync word has been sent / received, and de-asserts at the end of the packet.
+  writeRegister(CC1101_FSCTRL1, 0x0F); // change 06
+  writeRegister(CC1101_FSCTRL0, 0x00);
+  writeRegister(CC1101_MDMCFG4, 0x6A);
+  writeRegister(CC1101_MDMCFG3, 0x83);
+  writeRegister(CC1101_MDMCFG2, 0x10); // Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
+  writeRegister(CC1101_MDMCFG1, 0x22); // Disable FEC
+  writeRegister(CC1101_MDMCFG0, 0xF8);
+  writeRegister(CC1101_CHANNR, 0x00);
+  writeRegister(CC1101_DEVIATN, 0x50);
+  writeRegister(CC1101_FREND1, 0x56);
+  writeRegister(CC1101_FREND0, 0x10);
+  writeRegister(CC1101_MCSM0, 0x18); // no auto calibrate
+  writeRegister(CC1101_FOCCFG, 0x16);
+  writeRegister(CC1101_BSCFG, 0x6C);
+  writeRegister(CC1101_AGCCTRL2, 0x43);
+  writeRegister(CC1101_AGCCTRL1, 0x40);
+  writeRegister(CC1101_AGCCTRL0, 0x91);
+  writeRegister(CC1101_FSCAL3, 0xE9);
+  writeRegister(CC1101_FSCAL2, 0x21);
+  writeRegister(CC1101_FSCAL1, 0x00);
+  writeRegister(CC1101_FSCAL0, 0x1F);
+  writeRegister(CC1101_FSTEST, 0x59);
+  writeRegister(CC1101_TEST2, 0x81);
+  writeRegister(CC1101_TEST1, 0x35);
+  writeRegister(CC1101_TEST0, 0x09);
+  writeRegister(CC1101_PKTCTRL1, 0x04); // No address check, Append two bytes with status RSSI/LQI/CRC OK,
+  writeRegister(CC1101_PKTCTRL0, 0x32); // Infinite packet length mode, CRC disabled for TX and RX, No data whitening, Asynchronous serial mode, Data in on GDO0 and data out on either of the GDOx pins
+  writeRegister(CC1101_ADDR, 0x00);
+  writeRegister(CC1101_PKTLEN, 0xFF);
+
+  writeCommand(CC1101_SCAL);
+
+  // wait for calibration to finish
+  while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_IDLE)
+    yield();
+
+  writeRegister(CC1101_MCSM0, 0x18); // no auto calibrate
 
   writeCommand(CC1101_SIDLE);
   writeCommand(CC1101_SIDLE);
 
-  writeRegister(CC1101_MDMCFG2 , 0x00);   //Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
-  writeRegister(CC1101_IOCFG0 , 0x0D);      //Serial Data Output. Used for asynchronous serial mode.
+  writeRegister(CC1101_MDMCFG2, 0x00); // Enable digital DC blocking filter before demodulator, 2-FSK, Disable Manchester encoding/decoding, No preamble/sync
+  writeRegister(CC1101_IOCFG0, 0x0D);  // Serial Data Output. Used for asynchronous serial mode.
 
   writeCommand(CC1101_SRX);
 
-  while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_RX) yield();
+  while ((readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) != CC1101_MARCSTATE_RX)
+    yield();
 
   initReceiveMessage();
 }
 
-void  IthoCC1101::initReceiveMessage()
+void IthoCC1101::initReceiveMessage()
 {
   uint8_t marcState;
 
-  writeCommand(CC1101_SIDLE); //idle
+  writeCommand(CC1101_SIDLE); // idle
 
-  //set datarate
-  writeRegister(CC1101_MDMCFG4 , 0x6A); // set kBaud
-  writeRegister(CC1101_MDMCFG3 , 0x83); // set kBaud
-  writeRegister(CC1101_DEVIATN , 0x50);
+  // set datarate
+  writeRegister(CC1101_MDMCFG4, 0x6A); // set kBaud
+  writeRegister(CC1101_MDMCFG3, 0x83); // set kBaud
+  writeRegister(CC1101_DEVIATN, 0x50);
 
-  //set fifo mode with fixed packet length and sync bytes
-  //writeRegister(CC1101_PKTLEN , 63);      //63 bytes message (sync at beginning of message is removed by CC1101)
+  // set fifo mode with fixed packet length and sync bytes
+  // writeRegister(CC1101_PKTLEN , 63);      //63 bytes message (sync at beginning of message is removed by CC1101)
 
-  //set fifo mode with fixed packet length and sync bytes
-  writeRegister(CC1101_PKTCTRL0 , 0x02);
-  writeRegister(CC1101_SYNC1 , SYNC1);
-  writeRegister(CC1101_SYNC0 , SYNC0);
-  writeRegister(CC1101_MDMCFG2 , MDMCFG2);
-  writeRegister(CC1101_PKTCTRL1 , 0x00);
+  // set fifo mode with fixed packet length and sync bytes
+  writeRegister(CC1101_PKTCTRL0, 0x02);
+  writeRegister(CC1101_SYNC1, SYNC1);
+  writeRegister(CC1101_SYNC0, SYNC0);
+  writeRegister(CC1101_MDMCFG2, MDMCFG2);
+  writeRegister(CC1101_PKTCTRL1, 0x00);
 
-  writeCommand(CC1101_SRX); //switch to RX state
+  writeCommand(CC1101_SRX); // switch to RX state
 
   // Check that the RX state has been entered
   while (((marcState = readRegisterWithSyncProblem(CC1101_MARCSTATE, CC1101_STATUS_REGISTER)) & CC1101_BITS_MARCSTATE) != CC1101_MARCSTATE_RX)
   {
     if (marcState == CC1101_MARCSTATE_RXFIFO_OVERFLOW) // RX_OVERFLOW
-      writeCommand(CC1101_SFRX); //flush RX buffer
+      writeCommand(CC1101_SFRX);                       // flush RX buffer
   }
 }
 
-uint8_t IthoCC1101::receivePacket() {
+uint8_t IthoCC1101::receivePacket()
+{
   return readData(&inMessage, MAX_RAW);
 }
 
-bool IthoCC1101::checkForNewPacket() {
-  bool result = false;
-  if (parseMessageCommand()) {
+bool IthoCC1101::checkForNewPacket()
+{
+  receivePacket();
+  if (parseMessageCommand())
+  {
     initReceiveMessage();
-    result = true;
+    return true;
   }
-
-  return result;
+  return false;
 }
 
-bool IthoCC1101::parseMessageCommand() {
+bool IthoCC1101::parseMessageCommand()
+{
 
   messageDecode(&inMessage, &inIthoPacket);
 
   uint8_t dataPos = 0;
   inIthoPacket.error = 0;
+  inIthoPacket.remType = RemoteTypes::UNSETTYPE;
   inIthoPacket.command = IthoUnknown;
 
-  //first byte is the header of the message, this determines the structure of the rest of the message
-  //The bits are used as follows <00TTAAPP>
-  // 00 - Unused
-  // TT - Message type
-  // AA - Present DeviceID fields
-  // PP - Present Params
-  inIthoPacket.header  = inIthoPacket.dataDecoded[0];
+  // first byte is the header of the message, this determines the structure of the rest of the message
+  // The bits are used as follows <00TTAAPP>
+  //  00 - Unused
+  //  TT - Message type
+  //  AA - Present DeviceID fields
+  //  PP - Present Params
+  inIthoPacket.header = inIthoPacket.dataDecoded[0];
   dataPos++;
 
-  //packet type: RQ-Request, W-Write, I-Inform, RP-Response
-  if ((inIthoPacket.dataDecoded[0] >> 4) > 3) {
+  // packet type: RQ-Request, W-Write, I-Inform, RP-Response
+  if ((inIthoPacket.dataDecoded[0] >> 4) > 3)
+  {
     inIthoPacket.error = 1;
     return false;
   }
@@ -331,51 +328,60 @@ bool IthoCC1101::parseMessageCommand() {
   inIthoPacket.deviceId1 = 0;
   inIthoPacket.deviceId2 = 0;
 
-  //get DeviceID fields
+  // get DeviceID fields
   uint8_t idfield = (inIthoPacket.dataDecoded[0] >> 2) & 0x03;
 
-  if (idfield == 0x00 || idfield == 0x02 || idfield == 0x03) {
+  if (idfield == 0x00 || idfield == 0x02 || idfield == 0x03)
+  {
     inIthoPacket.deviceId0 = inIthoPacket.dataDecoded[dataPos] << 16 | inIthoPacket.dataDecoded[dataPos + 1] << 8 | inIthoPacket.dataDecoded[dataPos + 2];
     dataPos += 3;
-    if (idfield == 0x00 || idfield == 0x03) {
+    if (idfield == 0x00 || idfield == 0x03)
+    {
       inIthoPacket.deviceId1 = inIthoPacket.dataDecoded[dataPos] << 16 | inIthoPacket.dataDecoded[dataPos + 1] << 8 | inIthoPacket.dataDecoded[dataPos + 2];
       dataPos += 3;
     }
-    if (idfield == 0x00 || idfield == 0x02) {
+    if (idfield == 0x00 || idfield == 0x02)
+    {
       inIthoPacket.deviceId2 = inIthoPacket.dataDecoded[dataPos] << 16 | inIthoPacket.dataDecoded[dataPos + 1] << 8 | inIthoPacket.dataDecoded[dataPos + 2];
       dataPos += 3;
     }
   }
-  else {
+  else
+  {
     inIthoPacket.deviceId2 = inIthoPacket.dataDecoded[dataPos] << 16 | inIthoPacket.dataDecoded[dataPos + 1] << 8 | inIthoPacket.dataDecoded[dataPos + 2];
     dataPos += 3;
   }
 
-  //determine param0 present
-  if (inIthoPacket.dataDecoded[0] & 0x02) {
+  // determine param0 present
+  if (inIthoPacket.dataDecoded[0] & 0x02)
+  {
     inIthoPacket.param0 = inIthoPacket.dataDecoded[dataPos];
 
     dataPos++;
   }
-  else {
+  else
+  {
     inIthoPacket.param0 = 0;
   }
-  //determine param1 present
-  if (inIthoPacket.dataDecoded[0] & 0x01) {
+  // determine param1 present
+  if (inIthoPacket.dataDecoded[0] & 0x01)
+  {
     inIthoPacket.param1 = inIthoPacket.dataDecoded[dataPos];
     dataPos++;
   }
-  else {
+  else
+  {
     inIthoPacket.param1 = 0;
   }
 
-  //Get the two bytes of the opcode
+  // Get the two bytes of the opcode
   inIthoPacket.opcode = inIthoPacket.dataDecoded[dataPos] << 8 | inIthoPacket.dataDecoded[dataPos + 1];
   dataPos += 2;
 
-  //Payload length
+  // Payload length
   inIthoPacket.len = inIthoPacket.dataDecoded[dataPos];
-  if (inIthoPacket.len > MAX_PAYLOAD) {
+  if (inIthoPacket.len > MAX_PAYLOAD)
+  {
     inIthoPacket.error = 1;
     return false;
   }
@@ -383,14 +389,14 @@ bool IthoCC1101::parseMessageCommand() {
   dataPos++;
   inIthoPacket.payloadPos = dataPos;
 
-
-  //Now we have parsed all the variable fields and know the total lenth of the message
-  //with that we can determine if the message CRC is correct
+  // Now we have parsed all the variable fields and know the total lenth of the message
+  // with that we can determine if the message CRC is correct
   uint8_t mLen = inIthoPacket.payloadPos + inIthoPacket.len;
 
-  if (getCounter2(&inIthoPacket, mLen) != inIthoPacket.dataDecoded[mLen]) {
+  if (getCounter2(&inIthoPacket, mLen) != inIthoPacket.dataDecoded[mLen])
+  {
     inIthoPacket.error = 2;
-#if defined (CRC_FILTER)
+#if defined(CRC_FILTER)
     inIthoPacket.command = IthoUnknown;
     return false;
 #endif
@@ -400,58 +406,58 @@ bool IthoCC1101::parseMessageCommand() {
   // old message parse code below
   //
 
-  //deviceType of message type?
-  inIthoPacket.deviceType  = inIthoPacket.dataDecoded[0];
+  // deviceType of message type?
+  inIthoPacket.deviceType = inIthoPacket.dataDecoded[0];
 
-  //deviceID
+  // deviceID
   inIthoPacket.deviceId[0] = inIthoPacket.dataDecoded[1];
   inIthoPacket.deviceId[1] = inIthoPacket.dataDecoded[2];
   inIthoPacket.deviceId[2] = inIthoPacket.dataDecoded[3];
 
-  //counter1
+  // counter1
   inIthoPacket.counter = inIthoPacket.dataDecoded[4];
 
-  //handle command
-  switch (inIthoPacket.opcode) {
-    case IthoPacket::Type::BIND :
-      handleBind();
-      break;
-    case IthoPacket::Type::LEVEL :
-      handleLevel();
-      break;
-    case IthoPacket::Type::SETPOINT :
-      break;
-    case IthoPacket::Type::TIMER :
-      handleTimer();
-      break;
-    case IthoPacket::Type::STATUS :
-      handleStatus();
-      break;
-    case IthoPacket::Type::REMOTESTATUS :
-      handleRemotestatus();
-      break;
-    case IthoPacket::Type::TEMPHUM :
-      handleTemphum();
-      break;
-    case IthoPacket::Type::CO2 :
-      handleCo2();
-      break;
-    case IthoPacket::Type::BATTERY :
-      handleBattery();
-      break;
+  // handle command
+  switch (inIthoPacket.opcode)
+  {
+  case IthoPacket::Type::BIND:
+    handleBind();
+    break;
+  case IthoPacket::Type::LEVEL:
+    handleLevel();
+    break;
+  case IthoPacket::Type::SETPOINT:
+    handleLevel();
+    break;
+  case IthoPacket::Type::TIMER:
+    handleTimer();
+    break;
+  case IthoPacket::Type::STATUS:
+    handleStatus();
+    break;
+  case IthoPacket::Type::REMOTESTATUS:
+    handleRemotestatus();
+    break;
+  case IthoPacket::Type::TEMPHUM:
+    handleTemphum();
+    break;
+  case IthoPacket::Type::CO2:
+    handleCo2();
+    break;
+  case IthoPacket::Type::BATTERY:
+    handleBattery();
+    break;
   }
-
 
   return true;
 }
 
-bool IthoCC1101::checkIthoCommand(IthoPacket *itho, const uint8_t commandBytes[]) {
-  uint8_t offset = 0;
-  if (itho->deviceType == 28 || itho->deviceType == 24) offset = 2;
-  for (int i = 4; i < 6; i++)
+bool IthoCC1101::checkIthoCommand(IthoPacket *itho, const uint8_t commandBytes[])
+{
+  for (int i = 0; i < 6; i++)
   {
-    //if (i == 2 || i == 3) continue; //skip byte3 and byte4, rft-rv and co2-auto remote device seem to sometimes have a different number there
-    if ( (itho->dataDecoded[i + 5 + offset] != commandBytes[i]) && (itho->dataDecodedChk[i + 5 + offset] != commandBytes[i]) ) {
+    if (itho->dataDecoded[i + (itho->payloadPos - 3)] != commandBytes[i])
+    {
       return false;
     }
   }
@@ -464,34 +470,34 @@ void IthoCC1101::sendCommand(IthoCommand command)
   uint8_t maxTries = sendTries;
   uint8_t delaytime = 40;
 
-  //update itho packet data
+  // update itho packet data
   outIthoPacket.command = command;
   outIthoPacket.counter += 1;
 
-  //get message2 bytes
+  // get message2 bytes
   switch (command)
   {
-    case IthoJoin:
-      createMessageJoin(&outIthoPacket, &outMessage);
-      break;
+  case IthoJoin:
+    createMessageJoin(&outIthoPacket, &outMessage);
+    break;
 
-    case IthoLeave:
-      createMessageLeave(&outIthoPacket, &outMessage);
-      //the leave command needs to be transmitted for 1 second according the manual
-      maxTries = 30;
-      delaytime = 4;
-      break;
+  case IthoLeave:
+    createMessageLeave(&outIthoPacket, &outMessage);
+    // the leave command needs to be transmitted for 1 second according the manual
+    maxTries = 30;
+    delaytime = 4;
+    break;
 
-    default:
-      createMessageCommand(&outIthoPacket, &outMessage);
-      break;
+  default:
+    createMessageCommand(&outIthoPacket, &outMessage);
+    break;
   }
 
-  //send messages
+  // send messages
   for (int i = 0; i < maxTries; i++)
   {
 
-    //message2
+    // message2
     initSendMessage(outMessage.length);
     sendData(&outMessage);
 
@@ -501,12 +507,12 @@ void IthoCC1101::sendCommand(IthoCommand command)
   initReceive();
 }
 
-
 void IthoCC1101::createMessageStart(IthoPacket *itho, CC1101Packet *packet)
 {
 
-  //fixed, set start structure in data buffer manually
-  for (uint8_t i = 0; i < 7; i++) {
+  // fixed, set start structure in data buffer manually
+  for (uint8_t i = 0; i < 7; i++)
+  {
     packet->data[i] = 170;
   }
   packet->data[7] = 171;
@@ -518,76 +524,78 @@ void IthoCC1101::createMessageStart(IthoPacket *itho, CC1101Packet *packet)
   packet->data[13] = 42;
 
   //[start of command specific data]
-
 }
 
 void IthoCC1101::createMessageCommand(IthoPacket *itho, CC1101Packet *packet)
 {
 
-  //set start message structure
+  // set start message structure
   createMessageStart(itho, packet);
 
-  //set deviceType? (or messageType?), not sure what this is
-  itho->dataDecoded[0] = itho->deviceType;
+  int messagePos = 0;
+  // set deviceType? (or messageType?), not sure what this is
+  itho->dataDecoded[messagePos] = itho->deviceType;
 
-  //set deviceID
-  itho->dataDecoded[1] = itho->deviceId[0];
-  itho->dataDecoded[2] = itho->deviceId[1];
-  itho->dataDecoded[3] = itho->deviceId[2];
+  // set deviceID
+  itho->dataDecoded[++messagePos] = itho->deviceId[0];
+  itho->dataDecoded[++messagePos] = itho->deviceId[1];
+  itho->dataDecoded[++messagePos] = itho->deviceId[2];
 
-  //set counter1
-  itho->dataDecoded[4] = itho->counter;
+  // set counter1
+  itho->dataDecoded[++messagePos] = itho->counter;
 
-  //set command bytes on dataDecoded[5 - 10]
-  uint8_t *commandBytes = getMessageCommandBytes(itho->command);
-  for (uint8_t i = 0; i < 6; i++) {
-    itho->dataDecoded[i + 5] = commandBytes[i];
+  // set command bytes on dataDecoded[5 - 10]
+  const uint8_t *commandBytes = getMessageCommandBytes(itho->command);
+  for (uint8_t i = 0; i < 6; i++)
+  {
+    itho->dataDecoded[++messagePos] = commandBytes[i];
   }
 
-  //set counter2
-  itho->dataDecoded[11] = getCounter2(itho, 11);
+  // set counter2
+  itho->dataDecoded[++messagePos] = getCounter2(itho, 11);
 
-  itho->length = 12;
+  itho->length = messagePos + 1;
 
   packet->length = messageEncode(itho, packet);
   packet->length += 1;
 
-  //set end byte
+  // set end byte
   packet->data[packet->length] = 172;
   packet->length += 1;
 
-  //set end 'noise'
-  for (uint8_t i = packet->length; i < packet->length + 7; i++) {
+  // set end 'noise'
+  for (uint8_t i = packet->length; i < packet->length + 7; i++)
+  {
     packet->data[i] = 170;
   }
   packet->length += 7;
-
 }
 
 void IthoCC1101::createMessageJoin(IthoPacket *itho, CC1101Packet *packet)
 {
 
-  //set start message structure
+  // set start message structure
   createMessageStart(itho, packet);
 
-  //set deviceType? (or messageType?)
+  // set deviceType? (or messageType?)
   itho->dataDecoded[0] = itho->deviceType;
 
-  //set deviceID
+  // set deviceID
   itho->dataDecoded[1] = itho->deviceId[0];
   itho->dataDecoded[2] = itho->deviceId[1];
   itho->dataDecoded[3] = itho->deviceId[2];
 
-  //set counter1
+  // set counter1
   itho->dataDecoded[4] = itho->counter;
 
-  //set command bytes on dataDecoded[5 - ?]
-  uint8_t *commandBytes = getMessageCommandBytes(itho->command);
-  for (uint8_t i = 0; i < 6; i++) {
+  // set command bytes on dataDecoded[5 - ?]
+  const uint8_t *commandBytes = getMessageCommandBytes(itho->command);
+  for (uint8_t i = 0; i < 6; i++)
+  {
     itho->dataDecoded[i + 5] = commandBytes[i];
   }
 
-  //set deviceID
+  // set deviceID
   itho->dataDecoded[11] = itho->deviceId[0];
   itho->dataDecoded[12] = itho->deviceId[1];
   itho->dataDecoded[13] = itho->deviceId[2];
@@ -596,12 +604,12 @@ void IthoCC1101::createMessageJoin(IthoPacket *itho, CC1101Packet *packet)
   itho->dataDecoded[15] = 16;
   itho->dataDecoded[16] = 224;
 
-  //set deviceID
+  // set deviceID
   itho->dataDecoded[17] = itho->deviceId[0];
   itho->dataDecoded[18] = itho->deviceId[1];
   itho->dataDecoded[19] = itho->deviceId[2];
 
-  //set counter2
+  // set counter2
   itho->dataDecoded[20] = getCounter2(itho, 20);
 
   itho->length = 21;
@@ -609,47 +617,48 @@ void IthoCC1101::createMessageJoin(IthoPacket *itho, CC1101Packet *packet)
   packet->length = messageEncode(itho, packet);
   packet->length += 1;
 
-  //set end byte
+  // set end byte
   packet->data[packet->length] = 202;
   packet->length += 1;
 
-  //set end 'noise'
-  for (uint8_t i = packet->length; i < packet->length + 7; i++) {
+  // set end 'noise'
+  for (uint8_t i = packet->length; i < packet->length + 7; i++)
+  {
     packet->data[i] = 170;
   }
   packet->length += 7;
-
 }
 
 void IthoCC1101::createMessageLeave(IthoPacket *itho, CC1101Packet *packet)
 {
 
-  //set start message structure
+  // set start message structure
   createMessageStart(itho, packet);
 
-  //set deviceType? (or messageType?)
+  // set deviceType? (or messageType?)
   itho->dataDecoded[0] = itho->deviceType;
 
-  //set deviceID
+  // set deviceID
   itho->dataDecoded[1] = itho->deviceId[0];
   itho->dataDecoded[2] = itho->deviceId[1];
   itho->dataDecoded[3] = itho->deviceId[2];
 
-  //set counter1
+  // set counter1
   itho->dataDecoded[4] = itho->counter;
 
-  //set command bytes on dataDecoded[5 - 10]
-  uint8_t *commandBytes = getMessageCommandBytes(itho->command);
-  for (uint8_t i = 0; i < 6; i++) {
+  // set command bytes on dataDecoded[5 - 10]
+  const uint8_t *commandBytes = getMessageCommandBytes(itho->command);
+  for (uint8_t i = 0; i < 6; i++)
+  {
     itho->dataDecoded[i + 5] = commandBytes[i];
   }
 
-  //set deviceID
+  // set deviceID
   itho->dataDecoded[11] = itho->deviceId[0];
   itho->dataDecoded[12] = itho->deviceId[1];
   itho->dataDecoded[13] = itho->deviceId[2];
 
-  //set counter2
+  // set counter2
   itho->dataDecoded[14] = getCounter2(itho, 14);
 
   itho->length = 15;
@@ -657,44 +666,44 @@ void IthoCC1101::createMessageLeave(IthoPacket *itho, CC1101Packet *packet)
   packet->length = messageEncode(itho, packet);
   packet->length += 1;
 
-  //set end byte
+  // set end byte
   packet->data[packet->length] = 202;
   packet->length += 1;
 
-  //set end 'noise'
-  for (uint8_t i = packet->length; i < packet->length + 7; i++) {
+  // set end 'noise'
+  for (uint8_t i = packet->length; i < packet->length + 7; i++)
+  {
     packet->data[i] = 170;
   }
   packet->length += 7;
-
 }
 
-uint8_t* IthoCC1101::getMessageCommandBytes(IthoCommand command)
+const uint8_t *IthoCC1101::getMessageCommandBytes(IthoCommand command)
 {
   switch (command)
   {
-    case IthoStandby:
-      return (uint8_t*)&ithoMessageStandByCommandBytes[0];
-    case IthoHigh:
-      return (uint8_t*)&ithoMessageHighCommandBytes[0];
-    case IthoFull:
-      return (uint8_t*)&ithoMessageFullCommandBytes[0];
-    case IthoMedium:
-      return (uint8_t*)&ithoMessageMediumCommandBytes[0];
-    case IthoLow:
-      return (uint8_t*)&ithoMessageLowCommandBytes[0];
-    case IthoTimer1:
-      return (uint8_t*)&ithoMessageTimer1CommandBytes[0];
-    case IthoTimer2:
-      return (uint8_t*)&ithoMessageTimer2CommandBytes[0];
-    case IthoTimer3:
-      return (uint8_t*)&ithoMessageTimer3CommandBytes[0];
-    case IthoJoin:
-      return (uint8_t*)&ithoMessageJoinCommandBytes[0];
-    case IthoLeave:
-      return (uint8_t*)&ithoMessageLeaveCommandBytes[0];
-    default:
-      return (uint8_t*)&ithoMessageLowCommandBytes[0];
+  case IthoAway:
+    return &ithoMessageAwayCommandBytes[0];
+  case IthoHigh:
+    return &ithoMessageHighCommandBytes[0];
+  case IthoFull:
+    return &ithoMessageFullCommandBytes[0];
+  case IthoMedium:
+    return &ithoMessageMediumCommandBytes[0];
+  case IthoLow:
+    return &ithoMessageLowCommandBytes[0];
+  case IthoTimer1:
+    return &ithoMessageTimer1CommandBytes[0];
+  case IthoTimer2:
+    return &ithoMessageTimer2CommandBytes[0];
+  case IthoTimer3:
+    return &ithoMessageTimer3CommandBytes[0];
+  case IthoJoin:
+    return &ithoMessageCVERFTJoinCommandBytes[0];
+  case IthoLeave:
+    return &ithoMessageLeaveCommandBytes[0];
+  default:
+    return &ithoMessageLowCommandBytes[0];
   }
 }
 
@@ -703,80 +712,93 @@ uint8_t* IthoCC1101::getMessageCommandBytes(IthoCommand command)
    deviceType up to the last byte before counter2 subtracted
    from zero.
 */
-uint8_t IthoCC1101::getCounter2(IthoPacket *itho, uint8_t len) {
+uint8_t IthoCC1101::getCounter2(IthoPacket *itho, uint8_t len)
+{
 
   uint8_t val = 0;
 
-  for (uint8_t i = 0; i < len; i++) {
+  for (uint8_t i = 0; i < len; i++)
+  {
     val += itho->dataDecoded[i];
   }
 
   return 0 - val;
 }
 
-uint8_t IthoCC1101::messageEncode(IthoPacket *itho, CC1101Packet *packet) {
+uint8_t IthoCC1101::messageEncode(IthoPacket *itho, CC1101Packet *packet)
+{
 
-  uint8_t out_bytecounter = 14;   //index of Outbuf, start at offset 14, first part of the message is set manually
-  uint8_t out_bitcounter = 0;     //bit position of current outbuf byte
-  uint8_t out_patterncounter = 0; //bit counter to add 1 0 bit pattern after every 8 bits
-  uint8_t bitSelect = 4;          //bit position of the inData byte (4 - 7, 0 - 3)
-  uint8_t out_shift = 7;          //bit shift inData bit in position of outbuf byte
+  uint8_t out_bytecounter = 14;   // index of Outbuf, start at offset 14, first part of the message is set manually
+  uint8_t out_bitcounter = 0;     // bit position of current outbuf byte
+  uint8_t out_patterncounter = 0; // bit counter to add 1 0 bit pattern after every 8 bits
+  uint8_t bitSelect = 4;          // bit position of the inData byte (4 - 7, 0 - 3)
+  uint8_t out_shift = 7;          // bit shift inData bit in position of outbuf byte
 
-  //we need to zero the out buffer first cause we are using bitshifts
-  for (int i = out_bytecounter; i < sizeof(packet->data) / sizeof(packet->data[0]); i++) {
+  // we need to zero the out buffer first cause we are using bitshifts
+  for (unsigned int i = out_bytecounter; i < sizeof(packet->data) / sizeof(packet->data[0]); i++)
+  {
     packet->data[i] = 0;
   }
 
-  for (uint8_t dataByte = 0; dataByte < itho->length; dataByte++) {
-    for (uint8_t dataBit = 0; dataBit < 8; dataBit++) {                                     //process a full dataByte at a time resulting in 20 output bits (2.5 bytes) with the pattern 7x6x5x4x 10 3x2x1x0x 10 7x6x5x4x 10 3x2x1x0x 10 etc
-      if (out_bitcounter == 8) {                                                            //check if new byte is needed
+  for (uint8_t dataByte = 0; dataByte < itho->length; dataByte++)
+  {
+    for (uint8_t dataBit = 0; dataBit < 8; dataBit++)
+    { // process a full dataByte at a time resulting in 20 output bits (2.5 bytes) with the pattern 7x6x5x4x 10 3x2x1x0x 10 7x6x5x4x 10 3x2x1x0x 10 etc
+      if (out_bitcounter == 8)
+      { // check if new byte is needed
         out_bytecounter++;
         out_bitcounter = 0;
       }
 
-      if (out_patterncounter == 8) {                                                        //check if we have to start with a 1 0 pattern
+      if (out_patterncounter == 8)
+      { // check if we have to start with a 1 0 pattern
         out_patterncounter = 0;
         packet->data[out_bytecounter] = packet->data[out_bytecounter] | 1 << out_shift;
         out_shift--;
         out_bitcounter++;
         packet->data[out_bytecounter] = packet->data[out_bytecounter] | 0 << out_shift;
-        if (out_shift == 0) out_shift = 8;
+        if (out_shift == 0)
+          out_shift = 8;
         out_shift--;
         out_bitcounter++;
       }
 
-      if (out_bitcounter == 8) {                                                            //check if new byte is needed
+      if (out_bitcounter == 8)
+      { // check if new byte is needed
         out_bytecounter++;
         out_bitcounter = 0;
       }
 
-      //set the even bit
-      uint8_t bit = (itho->dataDecoded[dataByte] & (1 << bitSelect)) >> bitSelect;          //select bit and shift to bit pos 0
+      // set the even bit
+      uint8_t bit = (itho->dataDecoded[dataByte] & (1 << bitSelect)) >> bitSelect; // select bit and shift to bit pos 0
       bitSelect++;
-      if (bitSelect == 8) bitSelect = 0;
+      if (bitSelect == 8)
+        bitSelect = 0;
 
-      packet->data[out_bytecounter] = packet->data[out_bytecounter] | bit << out_shift;     //shift bit in corect pos of current outbuf byte
+      packet->data[out_bytecounter] = packet->data[out_bytecounter] | bit << out_shift; // shift bit in corect pos of current outbuf byte
       out_shift--;
       out_bitcounter++;
       out_patterncounter++;
 
-      //set the odd bit (inverse of even bit)
+      // set the odd bit (inverse of even bit)
       bit = ~bit & 0b00000001;
       packet->data[out_bytecounter] = packet->data[out_bytecounter] | bit << out_shift;
-      if (out_shift == 0) out_shift = 8;
+      if (out_shift == 0)
+        out_shift = 8;
       out_shift--;
       out_bitcounter++;
       out_patterncounter++;
-
     }
-
   }
-  if (out_bitcounter < 8) {                                                                   //add closing 1 0 pattern to fill last packet->data byte and ensure DC balance in the message
-    for (uint8_t i = out_bitcounter; i < 8; i += 2) {
+  if (out_bitcounter < 8)
+  { // add closing 1 0 pattern to fill last packet->data byte and ensure DC balance in the message
+    for (uint8_t i = out_bitcounter; i < 8; i += 2)
+    {
       packet->data[out_bytecounter] = packet->data[out_bytecounter] | 1 << out_shift;
       out_shift--;
       packet->data[out_bytecounter] = packet->data[out_bytecounter] | 0 << out_shift;
-      if (out_shift == 0) out_shift = 8;
+      if (out_shift == 0)
+        out_shift = 8;
       out_shift--;
     }
   }
@@ -784,63 +806,76 @@ uint8_t IthoCC1101::messageEncode(IthoPacket *itho, CC1101Packet *packet) {
   return out_bytecounter;
 }
 
-
-void IthoCC1101::messageDecode(CC1101Packet *packet, IthoPacket *itho) {
+void IthoCC1101::messageDecode(CC1101Packet *packet, IthoPacket *itho)
+{
 
   itho->length = 0;
   int lenInbuf = packet->length;
 
-  lenInbuf -= STARTBYTE; //correct for sync byte pos
+  lenInbuf -= STARTBYTE; // correct for sync byte pos
 
-  while (lenInbuf >= 5) {
+  while (lenInbuf >= 5)
+  {
     lenInbuf -= 5;
     itho->length += 2;
   }
-  if (lenInbuf >= 3) {
+  if (lenInbuf >= 3)
+  {
     itho->length++;
   }
 
-  for (int i = 0; i < sizeof(itho->dataDecoded) / sizeof(itho->dataDecoded[0]); i++) {
+  for (unsigned int i = 0; i < sizeof(itho->dataDecoded) / sizeof(itho->dataDecoded[0]); i++)
+  {
     itho->dataDecoded[i] = 0;
   }
-  for (int i = 0; i < sizeof(itho->dataDecodedChk) / sizeof(itho->dataDecodedChk[0]); i++) {
+  for (unsigned int i = 0; i < sizeof(itho->dataDecodedChk) / sizeof(itho->dataDecodedChk[0]); i++)
+  {
     itho->dataDecodedChk[i] = 0;
   }
 
-  uint8_t out_i = 0;                                  //byte index
-  uint8_t out_j = 4;                                  //bit index
-  uint8_t out_i_chk = 0;                              //byte index
-  uint8_t out_j_chk = 4;                              //bit index
-  uint8_t in_bitcounter = 0;                          //process per 10 input bits
+  uint8_t out_i = 0;         // byte index
+  uint8_t out_j = 4;         // bit index
+  uint8_t out_i_chk = 0;     // byte index
+  uint8_t out_j_chk = 4;     // bit index
+  uint8_t in_bitcounter = 0; // process per 10 input bits
 
-  for (int i = STARTBYTE; i < packet->length; i++) {
+  for (int i = STARTBYTE; i < packet->length; i++)
+  {
 
-    for (int j = 7; j > -1; j--) {
-      if (in_bitcounter == 0 || in_bitcounter == 2 || in_bitcounter == 4 || in_bitcounter == 6) { //select input bits for output
-        uint8_t x = packet->data[i];   //select input byte
-        x = x >> j;             //select input bit
+    for (int j = 7; j > -1; j--)
+    {
+      if (in_bitcounter == 0 || in_bitcounter == 2 || in_bitcounter == 4 || in_bitcounter == 6)
+      {                              // select input bits for output
+        uint8_t x = packet->data[i]; // select input byte
+        x = x >> j;                  // select input bit
         x = x & 0b00000001;
-        x = x << out_j;         //set value for output bit
+        x = x << out_j; // set value for output bit
         itho->dataDecoded[out_i] = itho->dataDecoded[out_i] | x;
-        out_j += 1;             //next output bit
-        if (out_j > 7) out_j = 0;
-        if (out_j == 4) out_i += 1;
+        out_j += 1; // next output bit
+        if (out_j > 7)
+          out_j = 0;
+        if (out_j == 4)
+          out_i += 1;
       }
-      if (in_bitcounter == 1 || in_bitcounter == 3 || in_bitcounter == 5 || in_bitcounter == 7) { //select input bits for check output
-        uint8_t x = packet->data[i];   //select input byte
-        x = x >> j;             //select input bit
+      if (in_bitcounter == 1 || in_bitcounter == 3 || in_bitcounter == 5 || in_bitcounter == 7)
+      {                              // select input bits for check output
+        uint8_t x = packet->data[i]; // select input byte
+        x = x >> j;                  // select input bit
         x = x & 0b00000001;
-        x = x << out_j_chk;         //set value for output bit
+        x = x << out_j_chk; // set value for output bit
         itho->dataDecodedChk[out_i_chk] = itho->dataDecodedChk[out_i_chk] | x;
-        out_j_chk += 1;             //next output bit
-        if (out_j_chk > 7) out_j_chk = 0;
-        if (out_j_chk == 4) {
-          itho->dataDecodedChk[out_i_chk] = ~itho->dataDecodedChk[out_i_chk]; //inverse bits
+        out_j_chk += 1; // next output bit
+        if (out_j_chk > 7)
+          out_j_chk = 0;
+        if (out_j_chk == 4)
+        {
+          itho->dataDecodedChk[out_i_chk] = ~itho->dataDecodedChk[out_i_chk]; // inverse bits
           out_i_chk += 1;
         }
       }
-      in_bitcounter += 1;     //continue cyling in groups of 10 bits
-      if (in_bitcounter > 9) in_bitcounter = 0;
+      in_bitcounter += 1; // continue cyling in groups of 10 bits
+      if (in_bitcounter > 9)
+        in_bitcounter = 0;
     }
   }
 }
@@ -874,130 +909,157 @@ bool IthoCC1101::checkID(const uint8_t *id)
   return true;
 }
 
-String IthoCC1101::getLastIDstr(bool ashex) {
+String IthoCC1101::getLastIDstr(bool ashex)
+{
   String str;
-  for (uint8_t i = 0; i < 3; i++) {
-    if (ashex) str += String(inIthoPacket.deviceId[i], HEX);
-    else str += String(inIthoPacket.deviceId[i]);
-    if (i < 2) str += ",";
+  for (uint8_t i = 0; i < 3; i++)
+  {
+    if (ashex)
+      str += String(inIthoPacket.deviceId[i], HEX);
+    else
+      str += String(inIthoPacket.deviceId[i]);
+    if (i < 2)
+      str += ",";
   }
   return str;
 }
 
-int * IthoCC1101::getLastID() {
+int *IthoCC1101::getLastID()
+{
   static int id[3];
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < 3; i++)
+  {
     id[i] = inIthoPacket.deviceId[i];
   }
   return id;
 }
 
-String IthoCC1101::getLastMessagestr(bool ashex) {
+String IthoCC1101::getLastMessagestr(bool ashex)
+{
   String str = "Length=" + String(inMessage.length) + ".";
-  for (uint8_t i = 0; i < inMessage.length; i++) {
-    if (ashex) str += String(inMessage.data[i], HEX);
-    else str += String(inMessage.data[i]);
-    if (i < inMessage.length - 1) str += ":";
+  for (uint8_t i = 0; i < inMessage.length; i++)
+  {
+    if (ashex)
+      str += String(inMessage.data[i], HEX);
+    else
+      str += String(inMessage.data[i]);
+    if (i < inMessage.length - 1)
+      str += ":";
   }
   return str;
 }
 
-String IthoCC1101::LastMessageDecoded() {
+String IthoCC1101::LastMessageDecoded()
+{
 
   String str;
 
+  if (inIthoPacket.length > 11)
+  {
 
-  if (inIthoPacket.length > 11) {
+    char bufhead[12]{};
+    snprintf(bufhead, sizeof(bufhead), "Header: %02X", inIthoPacket.header);
 
     str += String(MsgType[inIthoPacket.type]);
 
-    if (inIthoPacket.param0 == 0)  {
+    if (inIthoPacket.param0 == 0)
+    {
       str += " ---";
     }
-    else {
+    else
+    {
       str += " ";
       str += String(inIthoPacket.param0);
     }
 
-    if (inIthoPacket.deviceId0 == 0)  {
+    if (inIthoPacket.deviceId0 == 0)
+    {
       str += " --,--,--";
     }
-    else {
+    else
+    {
       str += " ";
-      char buf[10];
+      char buf[10]{};
       snprintf(buf, sizeof(buf), "%02X,%02X,%02X", inIthoPacket.deviceId0 >> 16 & 0xFF, inIthoPacket.deviceId0 >> 8 & 0xFF, inIthoPacket.deviceId0 & 0xFF);
       str += String(buf);
     }
-    if (inIthoPacket.deviceId1 == 0)  {
+    if (inIthoPacket.deviceId1 == 0)
+    {
       str += " --,--,--";
     }
-    else {
+    else
+    {
       str += " ";
-      char buf[10];
-      sprintf(buf, "%02X,%02X,%02X", inIthoPacket.deviceId1 >> 16 & 0xFF, inIthoPacket.deviceId1 >> 8 & 0xFF, inIthoPacket.deviceId1 & 0xFF);
+      char buf[10]{};
+      snprintf(buf, sizeof(buf), "%02X,%02X,%02X", inIthoPacket.deviceId1 >> 16 & 0xFF, inIthoPacket.deviceId1 >> 8 & 0xFF, inIthoPacket.deviceId1 & 0xFF);
       str += String(buf);
     }
-    if (inIthoPacket.deviceId2 == 0)  {
+    if (inIthoPacket.deviceId2 == 0)
+    {
       str += " --,--,--";
     }
-    else {
+    else
+    {
       str += " ";
-      char buf[10];
-      sprintf(buf, "%02X,%02X,%02X", inIthoPacket.deviceId2 >> 16 & 0xFF, inIthoPacket.deviceId2 >> 8 & 0xFF, inIthoPacket.deviceId2 & 0xFF);
+      char buf[10]{};
+      snprintf(buf, sizeof(buf), "%02X,%02X,%02X", inIthoPacket.deviceId2 >> 16 & 0xFF, inIthoPacket.deviceId2 >> 8 & 0xFF, inIthoPacket.deviceId2 & 0xFF);
       str += String(buf);
     }
-
 
     str += " ";
 
-    char buf[10];
-    sprintf(buf, "%04X", inIthoPacket.opcode);
+    char buf[10]{};
+    snprintf(buf, sizeof(buf), "%04X", inIthoPacket.opcode);
     str += String(buf);
 
     str += " ";
     str += String(inIthoPacket.len);
     str += ":";
 
-    for (int i = inIthoPacket.payloadPos; i < inIthoPacket.payloadPos + inIthoPacket.len; i++) {
-      sprintf(buf, "%02X", inIthoPacket.dataDecoded[i]);
+    for (int i = inIthoPacket.payloadPos; i < inIthoPacket.payloadPos + inIthoPacket.len; i++)
+    {
+      snprintf(buf, sizeof(buf), "%02X", inIthoPacket.dataDecoded[i]);
       str += String(buf);
-      if (i < inIthoPacket.payloadPos + inIthoPacket.len - 1) {
+      if (i < inIthoPacket.payloadPos + inIthoPacket.len - 1)
+      {
         str += ",";
       }
     }
     str += "\n";
-    //    for (int i = 0; i < inIthoPacket.length; i++) {
-    //      sprintf(buf, "%02X", inIthoPacket.dataDecoded[i]);
-    //      str += String(buf);
-    //      if (i < inIthoPacket.length - 1) str += ",";
-    //    }
-
   }
-  else {
-    for (uint8_t i = 0; i < inIthoPacket.length; i++) {
-      char buf[10];
-      sprintf(buf, "%02X", inIthoPacket.dataDecoded[i]);
+  else
+  {
+    for (uint8_t i = 0; i < inIthoPacket.length; i++)
+    {
+      char buf[10]{};
+      snprintf(buf, sizeof(buf), "%02X", inIthoPacket.dataDecoded[i]);
       str += String(buf);
-      if (i < inIthoPacket.length - 1) str += ",";
+      if (i < inIthoPacket.length - 1)
+        str += ",";
     }
-
   }
   str += "\n";
   return str;
-
 }
 
-bool IthoCC1101::addRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2) {
+bool IthoCC1101::addRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2, RemoteTypes remType)
+{
   uint32_t tempID = byte0 << 16 | byte1 << 8 | byte2;
-  return addRFDevice(tempID);
+  return addRFDevice(tempID, remType);
 }
-bool IthoCC1101::addRFDevice(uint32_t ID) {
-  if (!bindAllowed) return false;
-  if (checkRFDevice(ID)) return false; //device already registered
+bool IthoCC1101::addRFDevice(uint32_t ID, RemoteTypes remType)
+{
+  if (!bindAllowed)
+    return false;
+  if (checkRFDevice(ID))
+    return false; // device already registered
 
-  for (auto& item : ithoRF.device) {
-    if (item.deviceId == 0) { //pick the first available slot
+  for (auto &item : ithoRF.device)
+  {
+    if (item.deviceId == 0)
+    { // pick the first available slot
       item.deviceId = ID;
+      item.remType = remType;
       ithoRF.count++;
       return true;
     }
@@ -1005,19 +1067,26 @@ bool IthoCC1101::addRFDevice(uint32_t ID) {
   return false;
 }
 
-bool IthoCC1101::removeRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2) {
+bool IthoCC1101::removeRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2)
+{
   uint32_t tempID = byte0 << 16 | byte1 << 8 | byte2;
   return removeRFDevice(tempID);
 }
 
-bool IthoCC1101::removeRFDevice(uint32_t ID) {
-  if (!bindAllowed) return false;
-  if (!checkRFDevice(ID)) return false; //device not registered
+bool IthoCC1101::removeRFDevice(uint32_t ID)
+{
+  if (!bindAllowed)
+    return false;
+  if (!checkRFDevice(ID))
+    return false; // device not registered
 
-  for (auto& item : ithoRF.device) {
-    if (item.deviceId == ID) {
+  for (auto &item : ithoRF.device)
+  {
+    if (item.deviceId == ID)
+    {
       item.deviceId = 0;
-      //      strcpy(item.name, "");
+      //      strlcpy(item.name, "", sizeof(item.name));
+      item.remType = RemoteTypes::UNSETTYPE;
       item.lastCommand = IthoUnknown;
       item.co2 = 0xEFFF;
       item.temp = 0xEFFF;
@@ -1029,143 +1098,310 @@ bool IthoCC1101::removeRFDevice(uint32_t ID) {
     }
   }
 
-  return false; //not found
+  return false; // not found
 }
 
-bool IthoCC1101::checkRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2) {
+bool IthoCC1101::checkRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2)
+{
   uint32_t tempID = byte0 << 16 | byte1 << 8 | byte2;
   return checkRFDevice(tempID);
 }
 
-bool IthoCC1101::checkRFDevice(uint32_t ID) {
-  for (auto& item : ithoRF.device) {
-    if (item.deviceId == ID) {
+bool IthoCC1101::checkRFDevice(uint32_t ID)
+{
+  for (auto &item : ithoRF.device)
+  {
+    if (item.deviceId == ID)
+    {
       return true;
     }
   }
   return false;
 }
 
-void IthoCC1101::handleBind() {
+void IthoCC1101::handleBind()
+{
   uint32_t tempID = 0;
-  if (inIthoPacket.deviceId0 != 0) tempID = inIthoPacket.deviceId0;
-  else if (inIthoPacket.deviceId2 != 0) tempID = inIthoPacket.deviceId2;
-  else return;
+  if (inIthoPacket.deviceId0 != 0)
+    tempID = inIthoPacket.deviceId0;
+  else if (inIthoPacket.deviceId2 != 0)
+    tempID = inIthoPacket.deviceId2;
+  else
+    return;
 
-  if ( checkIthoCommand(&inIthoPacket, ithoMessageLeaveCommandBytes) ) {
+  if (checkIthoCommand(&inIthoPacket, ithoMessageLeaveCommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageAUTORFTLeaveCommandBytes))
+  {
     inIthoPacket.command = IthoLeave;
-    if (bindAllowed) {
+    if (bindAllowed)
+    {
       removeRFDevice(tempID);
     }
   }
-  else if ( checkIthoCommand(&inIthoPacket, ithoMessageJoinCommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageJoin2CommandBytes) ) {
+  else if (checkIthoCommand(&inIthoPacket, ithoMessageCVERFTJoinCommandBytes))
+  {
     inIthoPacket.command = IthoJoin;
-    if (bindAllowed) {
-      addRFDevice(tempID);
+    inIthoPacket.remType = RemoteTypes::RFTCVE;
+    if (bindAllowed)
+    {
+      addRFDevice(tempID, RemoteTypes::RFTCVE);
     }
   }
-  else if ( checkIthoCommand(&inIthoPacket, ithoMessageRVJoinCommandBytes) ) {
+  else if (checkIthoCommand(&inIthoPacket, ithoMessageAUTORFTJoinCommandBytes))
+  {
     inIthoPacket.command = IthoJoin;
-    if (bindAllowed) {
-      addRFDevice(tempID);
+    inIthoPacket.remType = RemoteTypes::RFTAUTO;
+    if (bindAllowed)
+    {
+      addRFDevice(tempID, RemoteTypes::RFTAUTO);
     }
-    //TODO: handle join handshake
+  }
+  else if (checkIthoCommand(&inIthoPacket, ithoMessageDFJoinCommandBytes))
+  {
+    inIthoPacket.command = IthoJoin;
+    inIthoPacket.remType = RemoteTypes::DEMANDFLOW;
+    if (bindAllowed)
+    {
+      addRFDevice(tempID, RemoteTypes::DEMANDFLOW);
+    }
+  }
+  else if (checkIthoCommand(&inIthoPacket, ithoMessageCO2JoinCommandBytes))
+  {
+    inIthoPacket.command = IthoJoin;
+    inIthoPacket.remType = RemoteTypes::RFTCO2;
+    if (bindAllowed)
+    {
+      addRFDevice(tempID, RemoteTypes::RFTCO2);
+    }
+    // TODO: handle join handshake
+  }
+  else if (checkIthoCommand(&inIthoPacket, ithoMessageRVJoinCommandBytes))
+  {
+    inIthoPacket.command = IthoJoin;
+    inIthoPacket.remType = RemoteTypes::RFTRV;
+    if (bindAllowed)
+    {
+      addRFDevice(tempID, RemoteTypes::RFTRV);
+    }
+    // TODO: handle join handshake
+  }
+  else if (checkIthoCommand(&inIthoPacket, orconMessageJoinCommandBytes))
+  {
+    inIthoPacket.command = IthoJoin;
+    inIthoPacket.remType = RemoteTypes::ORCON15LF01;
+    if (bindAllowed)
+    {
+      addRFDevice(tempID, RemoteTypes::ORCON15LF01);
+    }
+    // TODO: handle join handshake
   }
 
-  for (auto& item : ithoRF.device) {
-    if (item.deviceId == tempID) {
+  for (auto &item : ithoRF.device)
+  {
+    if (item.deviceId == tempID)
+    {
       item.lastCommand = inIthoPacket.command;
     }
   }
-  
 }
 
-void IthoCC1101::handleLevel() {
+void IthoCC1101::handleLevel()
+{
+  RemoteTypes remtype = RemoteTypes::UNSETTYPE;
   uint32_t tempID = 0;
-  if (inIthoPacket.deviceId0 != 0) tempID = inIthoPacket.deviceId0;
-  else if (inIthoPacket.deviceId2 != 0) tempID = inIthoPacket.deviceId2;
-  else return;
+  if (inIthoPacket.deviceId0 != 0)
+    tempID = inIthoPacket.deviceId0;
+  else if (inIthoPacket.deviceId2 != 0)
+    tempID = inIthoPacket.deviceId2;
+  else
+    return;
 
-  if (!allowAll) {
-    if (!checkRFDevice( tempID )) return;
+  if (!allowAll)
+  {
+    if (!checkRFDevice(tempID))
+      return;
   }
-  if ( checkIthoCommand(&inIthoPacket, ithoMessageHighCommandBytes) ) {
-    inIthoPacket.command = IthoHigh;
-  }
-  else if ( checkIthoCommand(&inIthoPacket, ithoMessageMediumCommandBytes) ) {
-    inIthoPacket.command = IthoMedium;
-  }
-  else if ( checkIthoCommand(&inIthoPacket, ithoMessageLowCommandBytes) ) {
-    inIthoPacket.command = IthoLow;
-  }
-  else if ( checkIthoCommand(&inIthoPacket, ithoMessageStandByCommandBytes) ) {
-    inIthoPacket.command = IthoStandby;
+  for (auto &item : ithoRF.device)
+  {
+    if (item.deviceId == tempID)
+    {
+      remtype = item.remType;
+    }
   }
 
-  for (auto& item : ithoRF.device) {
-    if (item.deviceId == tempID) {
+  if (remtype == RemoteTypes::ORCON15LF01)
+  {
+    if (checkIthoCommand(&inIthoPacket, orconMessageAwayCommandBytes))
+    {
+      inIthoPacket.command = IthoAway;
+    }
+    else if (checkIthoCommand(&inIthoPacket, orconMessageAutoCommandBytes))
+    {
+      inIthoPacket.command = IthoAuto;
+    }
+    else if (checkIthoCommand(&inIthoPacket, orconMessageButton1CommandBytes))
+    {
+      inIthoPacket.command = IthoLow;
+    }
+    else if (checkIthoCommand(&inIthoPacket, orconMessageButton2CommandBytes))
+    {
+      inIthoPacket.command = IthoMedium;
+    }
+    else if (checkIthoCommand(&inIthoPacket, orconMessageButton3CommandBytes))
+    {
+      inIthoPacket.command = IthoHigh;
+    }
+  }
+  else
+  {
+    if (checkIthoCommand(&inIthoPacket, ithoMessageLowCommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageAUTORFTLowCommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageDFLowCommandBytes))
+    {
+      inIthoPacket.command = IthoLow;
+    }
+    else if (checkIthoCommand(&inIthoPacket, ithoMessageMediumCommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageRV_CO2MediumCommandBytes))
+    {
+      inIthoPacket.command = IthoMedium;
+    }
+    else if (checkIthoCommand(&inIthoPacket, ithoMessageHighCommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageAUTORFTHighCommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageDFHighCommandBytes))
+    {
+      inIthoPacket.command = IthoHigh;
+    }
+    else if (checkIthoCommand(&inIthoPacket, ithoMessageAwayCommandBytes))
+    {
+      inIthoPacket.command = IthoAway;
+    }
+    else if (checkIthoCommand(&inIthoPacket, ithoMessageRV_CO2AutoCommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageAUTORFTAutoCommandBytes))
+    {
+      inIthoPacket.command = IthoAuto;
+    }
+    else if (checkIthoCommand(&inIthoPacket, ithoMessageRV_CO2AutoNightCommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageAUTORFTAutoNightCommandBytes))
+    {
+      inIthoPacket.command = IthoAutoNight;
+    }
+  }
+
+  for (auto &item : ithoRF.device)
+  {
+    if (item.deviceId == tempID)
+    {
       item.lastCommand = inIthoPacket.command;
     }
   }
-  
 }
 
-void IthoCC1101::handleTimer() {
+void IthoCC1101::handleTimer()
+{
+  RemoteTypes remtype = RemoteTypes::UNSETTYPE;
   uint32_t tempID = 0;
-  if (inIthoPacket.deviceId0 != 0) tempID = inIthoPacket.deviceId0;
-  else if (inIthoPacket.deviceId2 != 0) tempID = inIthoPacket.deviceId2;
-  else return;
+  if (inIthoPacket.deviceId0 != 0)
+    tempID = inIthoPacket.deviceId0;
+  else if (inIthoPacket.deviceId2 != 0)
+    tempID = inIthoPacket.deviceId2;
+  else
+    return;
 
-  if (!allowAll) {
-    if (!checkRFDevice( tempID )) return;
+  if (!allowAll)
+  {
+    if (!checkRFDevice(tempID))
+      return;
   }
-  if ( checkIthoCommand(&inIthoPacket, ithoMessageTimer1CommandBytes) ) {
-    inIthoPacket.command = IthoTimer1;
+  for (auto &item : ithoRF.device)
+  {
+    if (item.deviceId == tempID)
+    {
+      remtype = item.remType;
+    }
   }
-  else if ( checkIthoCommand(&inIthoPacket, ithoMessageTimer2CommandBytes) ) {
-    inIthoPacket.command = IthoTimer2;
+  if (remtype == RemoteTypes::ORCON15LF01)
+  {
+    if (checkIthoCommand(&inIthoPacket, orconMessageTimer1CommandBytes))
+    {
+      inIthoPacket.command = IthoTimer1;
+    }
+    else if (checkIthoCommand(&inIthoPacket, orconMessageTimer2CommandBytes))
+    {
+      inIthoPacket.command = IthoTimer2;
+    }
+    else if (checkIthoCommand(&inIthoPacket, orconMessageTimer3CommandBytes))
+    {
+      inIthoPacket.command = IthoTimer3;
+    }
   }
-  else if ( checkIthoCommand(&inIthoPacket, ithoMessageTimer3CommandBytes) ) {
-    inIthoPacket.command = IthoTimer3;
+  else
+  {
+    if (checkIthoCommand(&inIthoPacket, ithoMessageTimer1CommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageAUTORFTTimer1CommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageRV_CO2Timer1CommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageDFTimer1CommandBytes))
+    {
+      inIthoPacket.command = IthoTimer1;
+    }
+    else if (checkIthoCommand(&inIthoPacket, ithoMessageTimer2CommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageAUTORFTTimer2CommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageRV_CO2Timer2CommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageDFTimer2CommandBytes))
+    {
+      inIthoPacket.command = IthoTimer2;
+    }
+    else if (checkIthoCommand(&inIthoPacket, ithoMessageTimer3CommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageAUTORFTTimer3CommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageRV_CO2Timer3CommandBytes) || checkIthoCommand(&inIthoPacket, ithoMessageDFTimer3CommandBytes))
+    {
+      inIthoPacket.command = IthoTimer3;
+    }
+    else if (checkIthoCommand(&inIthoPacket, ithoMessageDFCook30CommandBytes))
+    {
+      inIthoPacket.command = IthoCook30;
+    }
+    else if (checkIthoCommand(&inIthoPacket, ithoMessageDFCook60CommandBytes))
+    {
+      inIthoPacket.command = IthoCook60;
+    }
   }
 
-  for (auto& item : ithoRF.device) {
-    if (item.deviceId == tempID) {
+  for (auto &item : ithoRF.device)
+  {
+    if (item.deviceId == tempID)
+    {
       item.lastCommand = inIthoPacket.command;
     }
   }
-
 }
-void IthoCC1101::handleStatus() {
+void IthoCC1101::handleStatus()
+{
   uint32_t tempID = 0;
-  if (inIthoPacket.deviceId0 != 0) tempID = inIthoPacket.deviceId0;
-  else if (inIthoPacket.deviceId2 != 0) tempID = inIthoPacket.deviceId2;
-  else return;
+  if (inIthoPacket.deviceId0 != 0)
+    tempID = inIthoPacket.deviceId0;
+  else if (inIthoPacket.deviceId2 != 0)
+    tempID = inIthoPacket.deviceId2;
+  else
+    return;
 
-  if (!checkRFDevice( tempID )) return;
+  if (!checkRFDevice(tempID))
+    return;
 
-  for (auto& item : ithoRF.device) {
-    if (item.deviceId == tempID) {
-      //store last command
+  for (auto &item : ithoRF.device)
+  {
+    if (item.deviceId == tempID)
+    {
+      // store last command
     }
   }
 }
-void IthoCC1101::handleRemotestatus() {
+void IthoCC1101::handleRemotestatus()
+{
   uint32_t tempID = 0;
-  if (inIthoPacket.deviceId0 != 0) tempID = inIthoPacket.deviceId0;
-  else if (inIthoPacket.deviceId2 != 0) tempID = inIthoPacket.deviceId2;
-  else return;
+  if (inIthoPacket.deviceId0 != 0)
+    tempID = inIthoPacket.deviceId0;
+  else if (inIthoPacket.deviceId2 != 0)
+    tempID = inIthoPacket.deviceId2;
+  else
+    return;
 
-  if (!checkRFDevice( tempID )) return;
+  if (!checkRFDevice(tempID))
+    return;
 
-  for (auto& item : ithoRF.device) {
-    if (item.deviceId == tempID) {
-      //store last command
+  for (auto &item : ithoRF.device)
+  {
+    if (item.deviceId == tempID)
+    {
+      // store last command
     }
   }
-
 }
-void IthoCC1101::handleTemphum() {
+void IthoCC1101::handleTemphum()
+{
   /*
      message length: 6
      message opcode: 0x12A0
@@ -1175,29 +1411,35 @@ void IthoCC1101::handleTemphum() {
      bytes[4:5] : dewpoint temperature
 
   */
-  if(inIthoPacket.error > 0) return;
+  if (inIthoPacket.error > 0)
+    return;
   uint32_t tempID = 0;
-  if (inIthoPacket.deviceId0 != 0) tempID = inIthoPacket.deviceId0;
-  else if (inIthoPacket.deviceId2 != 0) tempID = inIthoPacket.deviceId2;
-  else return;
+  if (inIthoPacket.deviceId0 != 0)
+    tempID = inIthoPacket.deviceId0;
+  else if (inIthoPacket.deviceId2 != 0)
+    tempID = inIthoPacket.deviceId2;
+  else
+    return;
 
-  if (!checkRFDevice( tempID )) return;
-  int32_t tempHum  = inIthoPacket.dataDecoded[inIthoPacket.payloadPos + 1];
+  if (!checkRFDevice(tempID))
+    return;
+  int32_t tempHum = inIthoPacket.dataDecoded[inIthoPacket.payloadPos + 1];
   int32_t tempTemp = inIthoPacket.dataDecoded[inIthoPacket.payloadPos + 2] << 8 | inIthoPacket.dataDecoded[inIthoPacket.payloadPos + 3];
   int32_t tempDewp = inIthoPacket.dataDecoded[inIthoPacket.payloadPos + 4] << 8 | inIthoPacket.dataDecoded[inIthoPacket.payloadPos + 5];
 
-  for (auto& item : ithoRF.device) {
-    if (item.deviceId == tempID) {
+  for (auto &item : ithoRF.device)
+  {
+    if (item.deviceId == tempID)
+    {
       item.temp = tempTemp;
       item.hum = tempHum;
       item.dewpoint = tempDewp;
     }
   }
-
 }
 
-
-void IthoCC1101::handleCo2() {
+void IthoCC1101::handleCo2()
+{
   /*
      message length: 3
      message opcode: 0x1298
@@ -1205,23 +1447,30 @@ void IthoCC1101::handleCo2() {
      bytes[1:2] : CO2 level
 
   */
-  if(inIthoPacket.error > 0) return;
+  if (inIthoPacket.error > 0)
+    return;
   uint32_t tempID = 0;
-  if (inIthoPacket.deviceId0 != 0) tempID = inIthoPacket.deviceId0;
-  else if (inIthoPacket.deviceId2 != 0) tempID = inIthoPacket.deviceId2;
-  else return;
+  if (inIthoPacket.deviceId0 != 0)
+    tempID = inIthoPacket.deviceId0;
+  else if (inIthoPacket.deviceId2 != 0)
+    tempID = inIthoPacket.deviceId2;
+  else
+    return;
 
-  if (!checkRFDevice( tempID )) return;
+  if (!checkRFDevice(tempID))
+    return;
   int32_t tempVal = inIthoPacket.dataDecoded[inIthoPacket.payloadPos + 1] << 8 | inIthoPacket.dataDecoded[inIthoPacket.payloadPos + 2];
 
-  for (auto& item : ithoRF.device) {
-    if (item.deviceId == tempID) {
+  for (auto &item : ithoRF.device)
+  {
+    if (item.deviceId == tempID)
+    {
       item.co2 = tempVal;
     }
   }
-
 }
-void IthoCC1101::handleBattery() {
+void IthoCC1101::handleBattery()
+{
   /*
      message length: 3
      message opcode: 0x1060
@@ -1230,23 +1479,47 @@ void IthoCC1101::handleBattery() {
      byte[2]  : battery state (0x01 OK, 0x00 LOW)
 
   */
-  if(inIthoPacket.error > 0) return;
+  if (inIthoPacket.error > 0)
+    return;
   uint32_t tempID = 0;
-  if (inIthoPacket.deviceId0 != 0) tempID = inIthoPacket.deviceId0;
-  else if (inIthoPacket.deviceId2 != 0) tempID = inIthoPacket.deviceId2;
-  else return;
+  if (inIthoPacket.deviceId0 != 0)
+    tempID = inIthoPacket.deviceId0;
+  else if (inIthoPacket.deviceId2 != 0)
+    tempID = inIthoPacket.deviceId2;
+  else
+    return;
 
-  if (!checkRFDevice( tempID )) return;
+  if (!checkRFDevice(tempID))
+    return;
   int32_t tempVal = 10;
-  if (inIthoPacket.dataDecoded[inIthoPacket.payloadPos + 1] == 0xFF) {
-    if (inIthoPacket.dataDecoded[inIthoPacket.payloadPos + 2] == 0x01) tempVal = 100;
+  if (inIthoPacket.dataDecoded[inIthoPacket.payloadPos + 1] == 0xFF)
+  {
+    if (inIthoPacket.dataDecoded[inIthoPacket.payloadPos + 2] == 0x01)
+      tempVal = 100;
   }
-  else {
+  else
+  {
     tempVal = (int32_t)inIthoPacket.dataDecoded[inIthoPacket.payloadPos + 1] / 2;
   }
-  for (auto& item : ithoRF.device) {
-    if (item.deviceId == tempID) {
+  for (auto &item : ithoRF.device)
+  {
+    if (item.deviceId == tempID)
+    {
       item.battery = tempVal;
     }
   }
+}
+
+const char *IthoCC1101::rem_cmd_to_name(IthoCommand code)
+{
+  size_t i;
+
+  for (i = 0; i < sizeof(remote_command_msg_table) / sizeof(remote_command_msg_table[0]); ++i)
+  {
+    if (remote_command_msg_table[i].code == code)
+    {
+      return remote_command_msg_table[i].msg;
+    }
+  }
+  return remote_unknown_msg;
 }

--- a/Master/Itho/IthoCC1101.h
+++ b/Master/Itho/IthoCC1101.h
@@ -1,36 +1,73 @@
 /*
- * Author: Klusjesman, supersjimmie, modified and reworked by arjenhiemstra 
- */
+   Author: Klusjesman, supersjimmie, modified and reworked by arjenhiemstra
+*/
 
-#ifndef __ITHOCC1101_H__
-#define __ITHOCC1101_H__
+#pragma once
 
 #include <stdio.h>
 #include "CC1101.h"
 #include "IthoPacket.h"
 
+#define MAX_NUMBER_OF_REMOTES 10
+
+//struct ithoRFCapab {
+//  std::string name;
+//  int32_t value;
+//};
+//
+//struct ithoRFDevices {
+//  uint32_t deviceId;
+//  std::vector<ithoRFCapab> Capabilities;
+//
+//  ithoRFDevices(): deviceId(0), Capabilities()
+//  {
+//  }
+//
+//};
+
+struct ithoRFDevice {
+  uint32_t deviceId {0};
+//  char name[16];
+  IthoCommand lastCommand {IthoUnknown};
+  int32_t co2 {0xEFFF};
+  int32_t temp {0xEFFF};
+  int32_t hum {0xEFFF};
+  int32_t dewpoint {0xEFFF};
+  int32_t battery {0xEFFF};
+};
+
+struct ithoRFDevices {
+  uint8_t count {0};
+  ithoRFDevice device[MAX_NUMBER_OF_REMOTES];
+};
 
 //pa table settings
 const uint8_t ithoPaTableSend[8] = {0x6F, 0x26, 0x2E, 0x8C, 0x87, 0xCD, 0xC7, 0xC0};
 const uint8_t ithoPaTableReceive[8] = {0x6F, 0x26, 0x2E, 0x7F, 0x8A, 0x84, 0xCA, 0xC4};
 
+const uint8_t messageOpcodeRemote[] =        { 0x22, 0xF1 };
+const uint8_t messageOpcodeRemoteAutoCO2[] = { 0x22, 0xF8 };
+const uint8_t messageOpcodeTimer[] =         { 0x22, 0xF3 };
+const uint8_t messageOpcodeRFTRV[] =         { 0x31, 0xE0 };
+const uint8_t messageOpcodeRFBind[] =        { 0x1F, 0xC9 };
+
 //message command bytes
-const uint8_t ithoMessageRVHighCommandBytes[] =   {49,224,4,0,0,200};
-const uint8_t ithoMessageHighCommandBytes[] =     {34,241,3,0,4,4};
-const uint8_t ithoMessageFullCommandBytes[] =     {34,241,3,0,4,4};
-const uint8_t ithoMessageMediumCommandBytes[] =   {34,241,3,0,3,4};
-const uint8_t ithoMessageRVMediumCommandBytes[] = {34,241,3,0,3,7};
-const uint8_t ithoMessageLowCommandBytes[] =      {34,241,3,0,2,4};
-const uint8_t ithoMessageRVLowCommandBytes[] =    {49,224,4,0,0,1};
-const uint8_t ithoMessageRVAutoCommandBytes[] =   {34,241,3,0,5,7};
-const uint8_t ithoMessageStandByCommandBytes[] =  {0,0,0,0,0,0};         //unkown, tbd
-const uint8_t ithoMessageTimer1CommandBytes[] =   {34,243,3,0,0,10};     //10 minutes full speed
-const uint8_t ithoMessageTimer2CommandBytes[] =   {34,243,3,0,0,20};     //20 minutes full speed
-const uint8_t ithoMessageTimer3CommandBytes[] =   {34,243,3,0,0,30};     //30 minutes full speed
-const uint8_t ithoMessageJoinCommandBytes[] =     {31,201,12,0,34,241};
-const uint8_t ithoMessageJoin2CommandBytes[] =    {31,201,12,99,34,248};  //join command of RFT AUTO Co2 remote
-const uint8_t ithoMessageRVJoinCommandBytes[] =   {31,201,24,0,49,224};  //join command of RFT-RV
-const uint8_t ithoMessageLeaveCommandBytes[] =    {31,201,6,0,31,201};
+const uint8_t ithoMessageRVHighCommandBytes[] =   {49, 224, 4, 0, 0, 200, 0};
+const uint8_t ithoMessageHighCommandBytes[] =     {34, 241, 3, 0, 4, 4};
+const uint8_t ithoMessageFullCommandBytes[] =     {34, 241, 3, 0, 4, 4};
+const uint8_t ithoMessageMediumCommandBytes[] =   {34, 241, 3, 0, 3, 4};
+const uint8_t ithoMessageRVMediumCommandBytes[] = {34, 241, 3, 0, 3, 7};
+const uint8_t ithoMessageLowCommandBytes[] =      {34, 241, 3, 0, 2, 4};
+const uint8_t ithoMessageRVLowCommandBytes[] =    {49, 224, 4, 0, 0, 1, 0};
+const uint8_t ithoMessageRVAutoCommandBytes[] =   {34, 241, 3, 0, 5, 7};
+const uint8_t ithoMessageStandByCommandBytes[] =  {0, 0, 0, 0, 0, 0};    //unkown, tbd
+const uint8_t ithoMessageTimer1CommandBytes[] =   {34, 243, 3, 0, 0, 10}; //10 minutes full speed
+const uint8_t ithoMessageTimer2CommandBytes[] =   {34, 243, 3, 0, 0, 20}; //20 minutes full speed
+const uint8_t ithoMessageTimer3CommandBytes[] =   {34, 243, 3, 0, 0, 30}; //30 minutes full speed
+const uint8_t ithoMessageJoinCommandBytes[] =     {31, 201, 12, 0, 34, 241};
+const uint8_t ithoMessageJoin2CommandBytes[] =    {31, 201, 12, 99, 34, 248}; //join command of RFT AUTO Co2 remote
+const uint8_t ithoMessageRVJoinCommandBytes[] =   {31, 201, 24, 0, 49, 224}; //join command of RFT-RV
+const uint8_t ithoMessageLeaveCommandBytes[] =    {31, 201, 6, 0, 31, 201};
 //itho rft-rv
 //unknown, high
 //148,216,43,49,224,4,0,0,200,0,3,127,244,78,11,155,154,225,11,96,138
@@ -43,6 +80,7 @@ const uint8_t ithoMessageLeaveCommandBytes[] =    {31,201,6,0,31,201};
 //join
 //151,149,65,31,201,24,0,49,224,151,149,65,0,18,160,151,149,65,1,16,224
 
+class IthoPacket;
 
 class IthoCC1101 : protected CC1101
 {
@@ -50,39 +88,100 @@ class IthoCC1101 : protected CC1101
     //receive
     CC1101Packet inMessage;                       //temp storage message2
     IthoPacket inIthoPacket;                        //stores last received message data
-    
+
     //send
     IthoPacket outIthoPacket;                       //stores state of "remote"
 
     //settings
     uint8_t sendTries;                            //number of times a command is send at one button press
-    
-  //functions
+
+    uint8_t cc_freq[3]; //FREQ0, FREQ1, FREQ2
+
+
+    //Itho remotes
+//    std::vector<ithoRFDevices> IthoRFDevices;
+    bool bindAllowed;
+    bool allowAll;
+    ithoRFDevices ithoRF;
+
+    //functions
   public:
     IthoCC1101(uint8_t counter = 0, uint8_t sendTries = 3);   //set initial counter value
     ~IthoCC1101();
-    
+
+
+
     //init
-    void init() { CC1101::init(); initReceive(); }                    //init,reset CC1101
+    void init() {
+      CC1101::init();  //init,reset CC1101
+      initReceive();
+    }
     void initReceive();
-    uint8_t getLastCounter() { return outIthoPacket.counter; }        //counter is increased before sending a command
-    void setSendTries(uint8_t sendTries) { this->sendTries = sendTries; }
-    void setDeviceID(uint8_t byte0, uint8_t byte1, uint8_t byte2) { this->outIthoPacket.deviceId[0] = byte0; this->outIthoPacket.deviceId[1] = byte1; this->outIthoPacket.deviceId[2] = byte2;}
-    
+    uint8_t getLastCounter() {
+      return outIthoPacket.counter;  //counter is increased before sending a command
+    }
+    void setSendTries(uint8_t sendTries) {
+      this->sendTries = sendTries;
+    }
+    void setDeviceID(uint8_t byte0, uint8_t byte1, uint8_t byte2) {
+      this->outIthoPacket.deviceId[0] = byte0;
+      this->outIthoPacket.deviceId[1] = byte1;
+      this->outIthoPacket.deviceId[2] = byte2;
+    }
+
+    bool addRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2);
+    bool addRFDevice(uint32_t ID);
+    bool removeRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2);
+    bool removeRFDevice(uint32_t ID);
+    bool checkRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2);
+    bool checkRFDevice(uint32_t ID);
+    void setBindAllowed(bool input) {
+      bindAllowed = input;
+    }
+    bool getBindAllowed() {
+      return bindAllowed;
+    }
+    void setAllowAll(bool input) {
+      allowAll = input;
+    }
+    bool getAllowAll() {
+      return allowAll;
+    }
+    const struct ithoRFDevices &getRFdevices() const {
+      return ithoRF;
+    }    
     //receive
-    bool checkForNewPacket();                       //check RX fifo for new data
-    IthoPacket getLastPacket() { return inIthoPacket; }           //retrieve last received/parsed packet from remote
-    IthoCommand getLastCommand() { return inIthoPacket.command; }           //retrieve last received/parsed command from remote
-    uint8_t getLastInCounter() { return inIthoPacket.counter; }           //retrieve last received/parsed command from remote
+    uint8_t receivePacket();  //read RX fifo
+    bool checkForNewPacket();
+    IthoPacket getLastPacket() {
+      return inIthoPacket;  //retrieve last received/parsed packet from remote
+    }
+    IthoCommand getLastCommand() {
+      return inIthoPacket.command;  //retrieve last received/parsed command from remote
+    }
+    uint8_t getLastInCounter() {
+      return inIthoPacket.counter;  //retrieve last received/parsed command from remote
+    }
     uint8_t ReadRSSI();
     bool checkID(const uint8_t *id);
     int * getLastID();
-    String getLastIDstr(bool ashex=true);
-    String getLastMessagestr(bool ashex=true);
+    String getLastIDstr(bool ashex = true);
+    String getLastMessagestr(bool ashex = true);
     String LastMessageDecoded();
-        
+
     //send
     void sendCommand(IthoCommand command);
+
+
+    void handleBind();
+    void handleLevel();
+    void handleTimer();
+    void handleStatus();
+    void handleRemotestatus();
+    void handleTemphum();
+    void handleCo2();
+    void handleBattery();
+
   protected:
   private:
     IthoCC1101( const IthoCC1101 &c);
@@ -90,15 +189,15 @@ class IthoCC1101 : protected CC1101
 
     //init CC1101 for receiving
     void initReceiveMessage();
-    
+
     //init CC1101 for sending
     void initSendMessage(uint8_t len);
-    void finishTransfer();    
-      
+    void finishTransfer();
+
     //parse received message
     bool parseMessageCommand();
     bool checkIthoCommand(IthoPacket *itho, const uint8_t commandBytes[]);
-    
+
     //send
     void createMessageStart(IthoPacket *itho, CC1101Packet *packet);
     void createMessageCommand(IthoPacket *itho, CC1101Packet *packet);
@@ -106,11 +205,9 @@ class IthoCC1101 : protected CC1101
     void createMessageLeave(IthoPacket *itho, CC1101Packet *packet);
     uint8_t* getMessageCommandBytes(IthoCommand command);
     uint8_t getCounter2(IthoPacket *itho, uint8_t len);
-    
+
     uint8_t messageEncode(IthoPacket *itho, CC1101Packet *packet);
     void messageDecode(CC1101Packet *packet, IthoPacket *itho);
-    
+
 
 }; //IthoCC1101
-
-#endif //__ITHOCC1101_H__

--- a/Master/Itho/IthoCC1101.h
+++ b/Master/Itho/IthoCC1101.h
@@ -52,7 +52,7 @@ class IthoCC1101 : protected CC1101
 		~IthoCC1101();
 		
 		//init
-		void init() { CC1101::init(); }											//init,reset CC1101
+		void init() { CC1101::init(); initReceive(); }							//init,reset CC1101
 		void initReceive();
 		uint8_t getLastCounter() { return outIthoPacket.counter; }				//counter is increased before sending a command
 		void setSendTries(uint8_t sendTries) { this->sendTries = sendTries; }
@@ -85,7 +85,7 @@ class IthoCC1101 : protected CC1101
 		void finishTransfer();		
 			
 		//parse received message
-		void parseMessageCommand();
+		bool parseMessageCommand();
 		
 		//send
     void createMessageStart(IthoPacket *itho, CC1101Packet *packet);

--- a/Master/Itho/IthoCC1101.h
+++ b/Master/Itho/IthoCC1101.h
@@ -86,6 +86,8 @@ class IthoCC1101 : protected CC1101
 			
 		//parse received message
 		bool parseMessageCommand();
+	    bool checkIthoCommand(IthoPacket *itho, const uint8_t commandBytes[]);
+		
 		
 		//send
     void createMessageStart(IthoPacket *itho, CC1101Packet *packet);

--- a/Master/Itho/IthoCC1101.h
+++ b/Master/Itho/IthoCC1101.h
@@ -17,6 +17,7 @@ const uint8_t ithoPaTableReceive[8] = {0x6F, 0x26, 0x2E, 0x7F, 0x8A, 0x84, 0xCA,
 //message command bytes
 const uint8_t ithoMessageRVHighCommandBytes[] =   {49,224,4,0,0,200};
 const uint8_t ithoMessageHighCommandBytes[] =     {34,241,3,0,4,4};
+const uint8_t ithoMessageFullCommandBytes[] =     {34,241,3,0,4,4};
 const uint8_t ithoMessageMediumCommandBytes[] =   {34,241,3,0,3,4};
 const uint8_t ithoMessageRVMediumCommandBytes[] = {34,241,3,0,3,7};
 const uint8_t ithoMessageLowCommandBytes[] =      {34,241,3,0,2,4};

--- a/Master/Itho/IthoCC1101.h
+++ b/Master/Itho/IthoCC1101.h
@@ -15,7 +15,6 @@ const uint8_t ithoPaTableSend[8] = {0x6F, 0x26, 0x2E, 0x8C, 0x87, 0xCD, 0xC7, 0x
 const uint8_t ithoPaTableReceive[8] = {0x6F, 0x26, 0x2E, 0x7F, 0x8A, 0x84, 0xCA, 0xC4};
 
 //message command bytes
-const uint8_t ithoMessagePowerCommandBytes[] =    {34,241,3,0,4,4};
 const uint8_t ithoMessageRVHighCommandBytes[] =   {49,224,4,0,0,200};
 const uint8_t ithoMessageHighCommandBytes[] =     {34,241,3,0,4,4};
 const uint8_t ithoMessageMediumCommandBytes[] =   {34,241,3,0,3,4};
@@ -28,85 +27,89 @@ const uint8_t ithoMessageTimer1CommandBytes[] =   {34,243,3,0,0,10};     //10 mi
 const uint8_t ithoMessageTimer2CommandBytes[] =   {34,243,3,0,0,20};     //20 minutes full speed
 const uint8_t ithoMessageTimer3CommandBytes[] =   {34,243,3,0,0,30};     //30 minutes full speed
 const uint8_t ithoMessageJoinCommandBytes[] =     {31,201,12,0,34,241};
-const uint8_t ithoMessageJoin2CommandBytes[] =    {31,201,12,99,34,248}; //join command of RFT AUTO Co2 remote
-const uint8_t ithoMessageRVJoinCommandBytes[] =   {31,201,24,0,49,224};  //join command of RFT-RV?
+const uint8_t ithoMessageJoin2CommandBytes[] =    {31,201,12,99,34,248};  //join command of RFT AUTO Co2 remote
+const uint8_t ithoMessageRVJoinCommandBytes[] =   {31,201,24,0,49,224};  //join command of RFT-RV
 const uint8_t ithoMessageLeaveCommandBytes[] =    {31,201,6,0,31,201};
+//itho rft-rv
+//unknown, high
+//148,216,43,49,224,4,0,0,200,0,3,127,244,78,11,155,154,225,11,96,138
+//148,216,43,49,224,4,0,0,200,0,3,127,51,80,47,233,94,6,189,114,73
+
+//low
+//148,216,43,49,224,4,0,0,1,0,202,127,242,212,160,123,15,64,7,129,33
+//148,216,43,34,241,3,0,4,4,194,127,255,189,90,107,88,72,115,49,192,105
+
+//join
+//151,149,65,31,201,24,0,49,224,151,149,65,0,18,160,151,149,65,1,16,224
 
 
 class IthoCC1101 : protected CC1101
 {
-	private:
-		//receive
-		CC1101Packet inMessage;												//temp storage message2
-		IthoPacket inIthoPacket;												//stores last received message data
-		
-		//send
-		IthoPacket outIthoPacket;												//stores state of "remote"
+  private:
+    //receive
+    CC1101Packet inMessage;                       //temp storage message2
+    IthoPacket inIthoPacket;                        //stores last received message data
+    
+    //send
+    IthoPacket outIthoPacket;                       //stores state of "remote"
 
-		//settings
-		uint8_t sendTries;														//number of times a command is send at one button press
-		
-	//functions
-	public:
-		IthoCC1101(uint8_t counter = 0, uint8_t sendTries = 3);		//set initial counter value
-		~IthoCC1101();
-		
-		//init
-		void init() { CC1101::init(); initReceive(); }							//init,reset CC1101
-		void initReceive();
-		uint8_t getLastCounter() { return outIthoPacket.counter; }				//counter is increased before sending a command
-		void setSendTries(uint8_t sendTries) { this->sendTries = sendTries; }
-		void setDeviceID(uint8_t byte0, uint8_t byte1, uint8_t byte2) { this->outIthoPacket.deviceId[0] = byte0; this->outIthoPacket.deviceId[1] = byte1; this->outIthoPacket.deviceId[2] = byte2;}
-		
-		//receive
-		bool checkForNewPacket();												//check RX fifo for new data
-		IthoPacket getLastPacket() { return inIthoPacket; }						//retrieve last received/parsed packet from remote
-		IthoCommand getLastCommand() { return inIthoPacket.command; }						//retrieve last received/parsed command from remote
-		uint8_t getLastInCounter() { return inIthoPacket.counter; }						//retrieve last received/parsed command from remote
-		uint8_t ReadRSSI();
-		bool checkID(const uint8_t *id);
-		String getLastIDstr(bool ashex=true);
+    //settings
+    uint8_t sendTries;                            //number of times a command is send at one button press
+    
+  //functions
+  public:
+    IthoCC1101(uint8_t counter = 0, uint8_t sendTries = 3);   //set initial counter value
+    ~IthoCC1101();
+    
+    //init
+    void init() { CC1101::init(); initReceive(); }                    //init,reset CC1101
+    void initReceive();
+    uint8_t getLastCounter() { return outIthoPacket.counter; }        //counter is increased before sending a command
+    void setSendTries(uint8_t sendTries) { this->sendTries = sendTries; }
+    void setDeviceID(uint8_t byte0, uint8_t byte1, uint8_t byte2) { this->outIthoPacket.deviceId[0] = byte0; this->outIthoPacket.deviceId[1] = byte1; this->outIthoPacket.deviceId[2] = byte2;}
+    
+    //receive
+    bool checkForNewPacket();                       //check RX fifo for new data
+    IthoPacket getLastPacket() { return inIthoPacket; }           //retrieve last received/parsed packet from remote
+    IthoCommand getLastCommand() { return inIthoPacket.command; }           //retrieve last received/parsed command from remote
+    uint8_t getLastInCounter() { return inIthoPacket.counter; }           //retrieve last received/parsed command from remote
+    uint8_t ReadRSSI();
+    bool checkID(const uint8_t *id);
     int * getLastID();
-		String getLastMessagestr(bool ashex=true);
+    String getLastIDstr(bool ashex=true);
+    String getLastMessagestr(bool ashex=true);
     String LastMessageDecoded();
-				
-		//send
-		void sendCommand(IthoCommand command);
-	protected:
-	private:
-		IthoCC1101( const IthoCC1101 &c);
-		IthoCC1101& operator=( const IthoCC1101 &c);
+        
+    //send
+    void sendCommand(IthoCommand command);
+  protected:
+  private:
+    IthoCC1101( const IthoCC1101 &c);
+    IthoCC1101& operator=( const IthoCC1101 &c);
 
-		//init CC1101 for receiving
-		void initReceiveMessage();
-		
-		//init CC1101 for sending
-		void initSendMessage(uint8_t len);
-		void finishTransfer();		
-			
-		//parse received message
-		bool parseMessageCommand();
-	    bool checkIthoCommand(IthoPacket *itho, const uint8_t commandBytes[]);
-		
-		
-		//send
+    //init CC1101 for receiving
+    void initReceiveMessage();
+    
+    //init CC1101 for sending
+    void initSendMessage(uint8_t len);
+    void finishTransfer();    
+      
+    //parse received message
+    bool parseMessageCommand();
+    bool checkIthoCommand(IthoPacket *itho, const uint8_t commandBytes[]);
+    
+    //send
     void createMessageStart(IthoPacket *itho, CC1101Packet *packet);
-		void createMessageCommand(IthoPacket *itho, CC1101Packet *packet);
-		void createMessageJoin(IthoPacket *itho, CC1101Packet *packet);
-		void createMessageLeave(IthoPacket *itho, CC1101Packet *packet);
-		uint8_t* getMessageCommandBytes(IthoCommand command);
-    //uint8_t* getMessageCommandBytes(IthoCommand);
+    void createMessageCommand(IthoPacket *itho, CC1101Packet *packet);
+    void createMessageJoin(IthoPacket *itho, CC1101Packet *packet);
+    void createMessageLeave(IthoPacket *itho, CC1101Packet *packet);
+    uint8_t* getMessageCommandBytes(IthoCommand command);
     uint8_t getCounter2(IthoPacket *itho, uint8_t len);
-		
+    
     uint8_t messageEncode(IthoPacket *itho, CC1101Packet *packet);
     void messageDecode(CC1101Packet *packet, IthoPacket *itho);
-		
-		//test
-		void testCreateMessage();
+    
 
 }; //IthoCC1101
-
-
-extern volatile uint32_t data1[];
 
 #endif //__ITHOCC1101_H__

--- a/Master/Itho/IthoCC1101.h
+++ b/Master/Itho/IthoCC1101.h
@@ -1,5 +1,5 @@
 /*
- * Author: Klusjesman, modified bij supersjimmie for Arduino/ESP8266
+ * Author: Klusjesman, supersjimmie, modified and reworked by arjenhiemstra 
  */
 
 #ifndef __ITHOCC1101_H__
@@ -14,69 +14,30 @@
 const uint8_t ithoPaTableSend[8] = {0x6F, 0x26, 0x2E, 0x8C, 0x87, 0xCD, 0xC7, 0xC0};
 const uint8_t ithoPaTableReceive[8] = {0x6F, 0x26, 0x2E, 0x7F, 0x8A, 0x84, 0xCA, 0xC4};
 
-//rft message 1 commands
-const uint8_t ithoMessage1HighCommandBytes[] = {1,84,213,85,50,203,52};
-const uint8_t ithoMessage1MediumCommandBytes[] = {1,84,213,85,74,213,52};
-const uint8_t ithoMessage1LowCommandBytes[] = {1,84,213,85,83,83,84};	
-const uint8_t ithoMessage1Timer1CommandBytes[] = {1,83,83,84,204,202,180};	
-const uint8_t ithoMessage1Timer2CommandBytes[] = {1,83,83,83,53,52,180};		
-const uint8_t ithoMessage1Timer3CommandBytes[] = {1,83,83,82,173,82,180};	
-const uint8_t ithoMessage1JoinCommandBytes[] = {0,170,171,85,84,202,180};
-const uint8_t ithoMessage1LeaveCommandBytes[] = {0,170,173,85,83,43,84};		
-
-//duco message1 commands
-const uint8_t ducoMessage1HighCommandBytes[] = {1,84,213,85,51,45,52};
-const uint8_t ducoMessage1MediumCommandBytes[] = {1,84,213,85,75,51,52};
-const uint8_t ducoMessage1LowCommandBytes[] = {1,84,213,85,82,181,84};
-const uint8_t ducoMessage1StandByCommandBytes[] = {1,85,53,84,205,85,52};
-const uint8_t ducoMessage1JoinCommandBytes[] = {0,170,171,85,85,44,180};
-const uint8_t ducoMessage1LeaveCommandBytes[] = {0,170,173,85,82,205,84};
-
-//message 2 commands
-const uint8_t ithoMessage2PowerCommandBytes[] = {6,89,150,170,165,101,90,150,85,149,101,90,102,85,150};
-const uint8_t ithoMessage2HighCommandBytes[] = {6,89,150,170,165,101,90,150,85,149,101,89,102,85,150};
-const uint8_t ithoMessage2MediumCommandBytes[] = {6,89,150,170,165,101,90,150,85,149,101,90,150,85,150};
-const uint8_t ithoMessage2LowCommandBytes[] = {6,89,150,170,165,101,90,150,85,149,101,89,150,85,150};
-const uint8_t ithoMessage2StandByCommandBytes[] = {6,89,150,170,165,101,90,150,85,149,101,90,86,85,150};
-const uint8_t ithoMessage2Timer1CommandBytes[] = {6,89,150,170,169,101,90,150,85,149,101,89,86,85,153};		//10 minutes full speed
-const uint8_t ithoMessage2Timer2CommandBytes[] = {6,89,150,170,169,101,90,150,85,149,101,89,86,149,150};	//20 minutes full speed
-const uint8_t ithoMessage2Timer3CommandBytes[] = {6,89,150,170,169,101,90,150,85,149,101,89,86,149,154};	//30 minutes full speed
-const uint8_t ithoMessage2JoinCommandBytes[] = {9,90,170,90,165,165,89,106,85,149,102,89,150,170,165};
-const uint8_t ithoMessage2LeaveCommandBytes[] = {9,90,170,90,165,165,89,166,85,149,105,90,170,90,165};
-
-//message 2, counter
-const uint8_t counterBytes24a[] = {1,2};
-const uint8_t counterBytes24b[] = {84,148,100,164,88,152,104,168};
-const uint8_t counterBytes25[] = {149,165,153,169,150,166,154,170};
-const uint8_t counterBytes26[] = {96,160};
-const uint8_t counterBytes41[] = {5, 10, 6, 9};
-const uint8_t counterBytes42[] = {90, 170, 106, 154};
-const uint8_t counterBytes43[] = {154, 90, 166, 102, 150, 86, 170, 106};
-//join/leave
-const uint8_t counterBytes64[] = {154,90,166,102,150,86,169,105,153,89,165,101,149,85,170,106};
-const uint8_t counterBytes65[] = {150,169,153,165,149,170,154,166};
-const uint8_t counterBytes66[] = {170,106};
-
-
-//state machine
-typedef enum IthoReceiveStates
-{
-	ExpectMessageStart,
-	ExpectNormalCommand,
-	ExpectJoinCommand,
-	ExpectLeaveCommand
-};
-
+//message command bytes
+const uint8_t ithoMessagePowerCommandBytes[] =    {34,241,3,0,4,4};
+const uint8_t ithoMessageRVHighCommandBytes[] =   {49,224,4,0,0,200};
+const uint8_t ithoMessageHighCommandBytes[] =     {34,241,3,0,4,4};
+const uint8_t ithoMessageMediumCommandBytes[] =   {34,241,3,0,3,4};
+const uint8_t ithoMessageRVMediumCommandBytes[] = {34,241,3,0,3,7};
+const uint8_t ithoMessageLowCommandBytes[] =      {34,241,3,0,2,4};
+const uint8_t ithoMessageRVLowCommandBytes[] =    {49,224,4,0,0,1};
+const uint8_t ithoMessageRVAutoCommandBytes[] =   {34,241,3,0,5,7};
+const uint8_t ithoMessageStandByCommandBytes[] =  {0,0,0,0,0,0};         //unkown, tbd
+const uint8_t ithoMessageTimer1CommandBytes[] =   {34,243,3,0,0,10};     //10 minutes full speed
+const uint8_t ithoMessageTimer2CommandBytes[] =   {34,243,3,0,0,20};     //20 minutes full speed
+const uint8_t ithoMessageTimer3CommandBytes[] =   {34,243,3,0,0,30};     //30 minutes full speed
+const uint8_t ithoMessageJoinCommandBytes[] =     {31,201,12,0,34,241};
+const uint8_t ithoMessageJoin2CommandBytes[] =    {0,0,0,0,0,0};         //join command of RFT AUTO Co2 remote, tbd
+const uint8_t ithoMessageRVJoinCommandBytes[] =   {31,201,24,0,49,224};  //join command of RFT-RV?
+const uint8_t ithoMessageLeaveCommandBytes[] =    {31,201,6,0,31,201};
 
 
 class IthoCC1101 : protected CC1101
 {
 	private:
 		//receive
-		IthoReceiveStates receiveState;											//state machine receive
-		unsigned long lastMessage1Received;										//used for timeout detection
-		CC1101Packet inMessage1;												//temp storage message1
-		CC1101Packet inMessage2;												//temp storage message2
+		CC1101Packet inMessage;												//temp storage message2
 		IthoPacket inIthoPacket;												//stores last received message data
 		
 		//send
@@ -95,8 +56,7 @@ class IthoCC1101 : protected CC1101
 		void initReceive();
 		uint8_t getLastCounter() { return outIthoPacket.counter; }				//counter is increased before sending a command
 		void setSendTries(uint8_t sendTries) { this->sendTries = sendTries; }
-		
-		//- deviceid should be a setting as well? random gen function? TODO
+		void setDeviceID(uint8_t byte0, uint8_t byte1, uint8_t byte2) { this->outIthoPacket.deviceId[0] = byte0; this->outIthoPacket.deviceId[1] = byte1; this->outIthoPacket.deviceId[2] = byte2;}
 		
 		//receive
 		bool checkForNewPacket();												//check RX fifo for new data
@@ -106,8 +66,9 @@ class IthoCC1101 : protected CC1101
 		uint8_t ReadRSSI();
 		bool checkID(const uint8_t *id);
 		String getLastIDstr(bool ashex=true);
-		String getLastMessage2str(bool ashex=true);
-
+    int * getLastID();
+		String getLastMessagestr(bool ashex=true);
+    String LastMessageDecoded();
 				
 		//send
 		void sendCommand(IthoCommand command);
@@ -117,56 +78,26 @@ class IthoCC1101 : protected CC1101
 		IthoCC1101& operator=( const IthoCC1101 &c);
 
 		//init CC1101 for receiving
-		void initReceiveMessage1();
-		void initReceiveMessage2(IthoMessageType expectedMessageType);
+		void initReceiveMessage();
 		
 		//init CC1101 for sending
-		void initSendMessage1();
-		void initSendMessage2(IthoCommand command);
+		void initSendMessage(uint8_t len);
 		void finishTransfer();		
-		
-		//receive message validation
-		bool isValidMessageStart();
-		bool isValidMessageCommand();	
-		bool isValidMessageJoin();
-		bool isValidMessageLeave();
 			
 		//parse received message
-		void parseReceivedPackets();
-		void parseMessageStart();
 		void parseMessageCommand();
-		void parseMessageJoin();
-		void parseMessageLeave();
 		
 		//send
-		void createMessageStart(IthoPacket *itho, CC1101Packet *packet);
+    void createMessageStart(IthoPacket *itho, CC1101Packet *packet);
 		void createMessageCommand(IthoPacket *itho, CC1101Packet *packet);
 		void createMessageJoin(IthoPacket *itho, CC1101Packet *packet);
 		void createMessageLeave(IthoPacket *itho, CC1101Packet *packet);
-		uint8_t* getMessage1CommandBytes(IthoCommand command);
-		uint8_t* getMessage2CommandBytes(IthoCommand command);
+		uint8_t* getMessageCommandBytes(IthoCommand command);
+    //uint8_t* getMessageCommandBytes(IthoCommand);
+    uint8_t getCounter2(IthoPacket *itho, uint8_t len);
 		
-		//counter bytes calculation (send)
-		uint8_t getMessage1Byte18(IthoCommand command);
-		IthoCommand getMessage1PreviousCommand(uint8_t byte18);
-		uint8_t calculateMessage2Byte24(uint8_t counter);
-		uint8_t calculateMessage2Byte25(uint8_t counter);
-		uint8_t calculateMessage2Byte26(uint8_t counter);
-		uint8_t calculateMessage2Byte41(uint8_t counter, IthoCommand command);
-		uint8_t calculateMessage2Byte42(uint8_t counter, IthoCommand command);
-		uint8_t calculateMessage2Byte43(uint8_t counter, IthoCommand command);
-		uint8_t calculateMessage2Byte49(uint8_t counter);
-		uint8_t calculateMessage2Byte50(uint8_t counter);
-		uint8_t calculateMessage2Byte51(uint8_t counter);
-		uint8_t calculateMessage2Byte64(uint8_t counter);
-		uint8_t calculateMessage2Byte65(uint8_t counter);
-		uint8_t calculateMessage2Byte66(uint8_t counter);
-		
-		//counter calculation (receive)
-		uint8_t calculateMessageCounter(uint8_t byte24, uint8_t byte25, uint8_t byte26);
-		
-		//general
-		uint8_t getCounterIndex(const uint8_t *arr, uint8_t length, uint8_t value);		
+    uint8_t messageEncode(IthoPacket *itho, CC1101Packet *packet);
+    void messageDecode(CC1101Packet *packet, IthoPacket *itho);
 		
 		//test
 		void testCreateMessage();

--- a/Master/Itho/IthoCC1101.h
+++ b/Master/Itho/IthoCC1101.h
@@ -28,7 +28,7 @@ const uint8_t ithoMessageTimer1CommandBytes[] =   {34,243,3,0,0,10};     //10 mi
 const uint8_t ithoMessageTimer2CommandBytes[] =   {34,243,3,0,0,20};     //20 minutes full speed
 const uint8_t ithoMessageTimer3CommandBytes[] =   {34,243,3,0,0,30};     //30 minutes full speed
 const uint8_t ithoMessageJoinCommandBytes[] =     {31,201,12,0,34,241};
-const uint8_t ithoMessageJoin2CommandBytes[] =    {0,0,0,0,0,0};         //join command of RFT AUTO Co2 remote, tbd
+const uint8_t ithoMessageJoin2CommandBytes[] =    {31,201,12,99,34,248}; //join command of RFT AUTO Co2 remote
 const uint8_t ithoMessageRVJoinCommandBytes[] =   {31,201,24,0,49,224};  //join command of RFT-RV?
 const uint8_t ithoMessageLeaveCommandBytes[] =    {31,201,6,0,31,201};
 

--- a/Master/Itho/IthoCC1101.h
+++ b/Master/Itho/IthoCC1101.h
@@ -4,210 +4,205 @@
 
 #pragma once
 
-#include <stdio.h>
+#include <cstdio>
+#include <string>
+
 #include "CC1101.h"
 #include "IthoPacket.h"
 
-#define MAX_NUMBER_OF_REMOTES 10
+#define MAX_NUM_OF_REMOTES 10
 
-//struct ithoRFCapab {
-//  std::string name;
-//  int32_t value;
-//};
-//
-//struct ithoRFDevices {
-//  uint32_t deviceId;
-//  std::vector<ithoRFCapab> Capabilities;
-//
-//  ithoRFDevices(): deviceId(0), Capabilities()
-//  {
-//  }
-//
-//};
-
-struct ithoRFDevice {
-  uint32_t deviceId {0};
-//  char name[16];
-  IthoCommand lastCommand {IthoUnknown};
-  int32_t co2 {0xEFFF};
-  int32_t temp {0xEFFF};
-  int32_t hum {0xEFFF};
-  int32_t dewpoint {0xEFFF};
-  int32_t battery {0xEFFF};
+struct ithoRFDevice
+{
+  uint32_t deviceId{0};
+  RemoteTypes remType;
+  //  char name[16];
+  IthoCommand lastCommand{IthoUnknown};
+  int32_t co2{0xEFFF};
+  int32_t temp{0xEFFF};
+  int32_t hum{0xEFFF};
+  int32_t dewpoint{0xEFFF};
+  int32_t battery{0xEFFF};
 };
 
-struct ithoRFDevices {
-  uint8_t count {0};
-  ithoRFDevice device[MAX_NUMBER_OF_REMOTES];
+struct ithoRFDevices
+{
+  uint8_t count{0};
+  ithoRFDevice device[MAX_NUM_OF_REMOTES];
 };
 
-//pa table settings
+// pa table settings
 const uint8_t ithoPaTableSend[8] = {0x6F, 0x26, 0x2E, 0x8C, 0x87, 0xCD, 0xC7, 0xC0};
 const uint8_t ithoPaTableReceive[8] = {0x6F, 0x26, 0x2E, 0x7F, 0x8A, 0x84, 0xCA, 0xC4};
-
-const uint8_t messageOpcodeRemote[] =        { 0x22, 0xF1 };
-const uint8_t messageOpcodeRemoteAutoCO2[] = { 0x22, 0xF8 };
-const uint8_t messageOpcodeTimer[] =         { 0x22, 0xF3 };
-const uint8_t messageOpcodeRFTRV[] =         { 0x31, 0xE0 };
-const uint8_t messageOpcodeRFBind[] =        { 0x1F, 0xC9 };
-
-//message command bytes
-const uint8_t ithoMessageRVHighCommandBytes[] =   {49, 224, 4, 0, 0, 200, 0};
-const uint8_t ithoMessageHighCommandBytes[] =     {34, 241, 3, 0, 4, 4};
-const uint8_t ithoMessageFullCommandBytes[] =     {34, 241, 3, 0, 4, 4};
-const uint8_t ithoMessageMediumCommandBytes[] =   {34, 241, 3, 0, 3, 4};
-const uint8_t ithoMessageRVMediumCommandBytes[] = {34, 241, 3, 0, 3, 7};
-const uint8_t ithoMessageLowCommandBytes[] =      {34, 241, 3, 0, 2, 4};
-const uint8_t ithoMessageRVLowCommandBytes[] =    {49, 224, 4, 0, 0, 1, 0};
-const uint8_t ithoMessageRVAutoCommandBytes[] =   {34, 241, 3, 0, 5, 7};
-const uint8_t ithoMessageStandByCommandBytes[] =  {0, 0, 0, 0, 0, 0};    //unkown, tbd
-const uint8_t ithoMessageTimer1CommandBytes[] =   {34, 243, 3, 0, 0, 10}; //10 minutes full speed
-const uint8_t ithoMessageTimer2CommandBytes[] =   {34, 243, 3, 0, 0, 20}; //20 minutes full speed
-const uint8_t ithoMessageTimer3CommandBytes[] =   {34, 243, 3, 0, 0, 30}; //30 minutes full speed
-const uint8_t ithoMessageJoinCommandBytes[] =     {31, 201, 12, 0, 34, 241};
-const uint8_t ithoMessageJoin2CommandBytes[] =    {31, 201, 12, 99, 34, 248}; //join command of RFT AUTO Co2 remote
-const uint8_t ithoMessageRVJoinCommandBytes[] =   {31, 201, 24, 0, 49, 224}; //join command of RFT-RV
-const uint8_t ithoMessageLeaveCommandBytes[] =    {31, 201, 6, 0, 31, 201};
-//itho rft-rv
-//unknown, high
-//148,216,43,49,224,4,0,0,200,0,3,127,244,78,11,155,154,225,11,96,138
-//148,216,43,49,224,4,0,0,200,0,3,127,51,80,47,233,94,6,189,114,73
-
-//low
-//148,216,43,49,224,4,0,0,1,0,202,127,242,212,160,123,15,64,7,129,33
-//148,216,43,34,241,3,0,4,4,194,127,255,189,90,107,88,72,115,49,192,105
-
-//join
-//151,149,65,31,201,24,0,49,224,151,149,65,0,18,160,151,149,65,1,16,224
 
 class IthoPacket;
 
 class IthoCC1101 : protected CC1101
 {
-  private:
-    //receive
-    CC1101Packet inMessage;                       //temp storage message2
-    IthoPacket inIthoPacket;                        //stores last received message data
+private:
+  // receive
+  CC1101Packet inMessage;  // temp storage message2
+  IthoPacket inIthoPacket; // stores last received message data
 
-    //send
-    IthoPacket outIthoPacket;                       //stores state of "remote"
+  // send
+  IthoPacket outIthoPacket; // stores state of "remote"
 
-    //settings
-    uint8_t sendTries;                            //number of times a command is send at one button press
+  // settings
+  uint8_t sendTries;  // number of times a command is send at one button press
+  uint8_t cc_freq[3]; // FREQ0, FREQ1, FREQ2
 
-    uint8_t cc_freq[3]; //FREQ0, FREQ1, FREQ2
+  // Itho remotes
+  bool bindAllowed;
+  bool allowAll;
+  ithoRFDevices ithoRF;
 
+  typedef struct
+  {
+    IthoCommand code;
+    const char *msg;
+  } remote_command_char;
 
-    //Itho remotes
-//    std::vector<ithoRFDevices> IthoRFDevices;
-    bool bindAllowed;
-    bool allowAll;
-    ithoRFDevices ithoRF;
+  const remote_command_char remote_command_msg_table[15]{
+      {IthoUnknown, "IthoUnknown"},
+      {IthoJoin, "IthoJoin"},
+      {IthoLeave, "IthoLeave"},
+      {IthoAway, "IthoAway"},
+      {IthoLow, "IthoLow"},
+      {IthoMedium, "IthoMedium"},
+      {IthoHigh, "IthoHigh"},
+      {IthoFull, "IthoFull"},
+      {IthoTimer1, "IthoTimer1"},
+      {IthoTimer2, "IthoTimer2"},
+      {IthoTimer3, "IthoTimer3"},
+      {IthoAuto, "IthoAuto"},
+      {IthoAutoNight, "IthoAutoNight"},
+      {IthoCook30, "IthoCook30"},
+      {IthoCook60, "IthoCook60"}};
 
-    //functions
-  public:
-    IthoCC1101(uint8_t counter = 0, uint8_t sendTries = 3);   //set initial counter value
-    ~IthoCC1101();
+  const char *remote_unknown_msg = "CMD UNKNOWN ERROR";
+  // functions
+public:
+  IthoCC1101(uint8_t counter = 0, uint8_t sendTries = 3); // set initial counter value
+  ~IthoCC1101();
 
+  // init
+  void init()
+  {
+    CC1101::init(); // init,reset CC1101
+    initReceive();
+  }
+  void initReceive();
+  uint8_t getLastCounter()
+  {
+    return outIthoPacket.counter; // counter is increased before sending a command
+  }
+  void setSendTries(uint8_t sendTries)
+  {
+    this->sendTries = sendTries;
+  }
+  void setDeviceID(uint8_t byte0, uint8_t byte1, uint8_t byte2)
+  {
+    this->outIthoPacket.deviceId[0] = byte0;
+    this->outIthoPacket.deviceId[1] = byte1;
+    this->outIthoPacket.deviceId[2] = byte2;
+  }
 
+  bool addRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2, RemoteTypes deviceType);
+  bool addRFDevice(uint32_t ID, RemoteTypes deviceType);
+  bool removeRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2);
+  bool removeRFDevice(uint32_t ID);
+  bool checkRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2);
+  bool checkRFDevice(uint32_t ID);
+  void setBindAllowed(bool input)
+  {
+    bindAllowed = input;
+  }
+  bool getBindAllowed()
+  {
+    return bindAllowed;
+  }
+  void setAllowAll(bool input)
+  {
+    allowAll = input;
+  }
+  bool getAllowAll()
+  {
+    return allowAll;
+  }
+  const struct ithoRFDevices &getRFdevices() const
+  {
+    return ithoRF;
+  }
+  // receive
+  uint8_t receivePacket(); // read RX fifo
+  bool checkForNewPacket();
+  IthoPacket getLastPacket()
+  {
+    return inIthoPacket; // retrieve last received/parsed packet from remote
+  }
+  IthoCommand getLastCommand()
+  {
+    return inIthoPacket.command; // retrieve last received/parsed command from remote
+  }
+  RemoteTypes getLastRemType()
+  {
+    return inIthoPacket.remType; // retrieve last received/parsed rf device type
+  }
+  uint8_t getLastInCounter()
+  {
+    return inIthoPacket.counter; // retrieve last received/parsed command from remote
+  }
+  uint32_t getFrequency()
+  {
+    return ((uint32_t)cc_freq[2] << 16) | ((uint32_t)cc_freq[1] << 8) | ((uint32_t)cc_freq[0] << 0);
+  }
 
-    //init
-    void init() {
-      CC1101::init();  //init,reset CC1101
-      initReceive();
-    }
-    void initReceive();
-    uint8_t getLastCounter() {
-      return outIthoPacket.counter;  //counter is increased before sending a command
-    }
-    void setSendTries(uint8_t sendTries) {
-      this->sendTries = sendTries;
-    }
-    void setDeviceID(uint8_t byte0, uint8_t byte1, uint8_t byte2) {
-      this->outIthoPacket.deviceId[0] = byte0;
-      this->outIthoPacket.deviceId[1] = byte1;
-      this->outIthoPacket.deviceId[2] = byte2;
-    }
+  uint8_t ReadRSSI();
+  bool checkID(const uint8_t *id);
+  int *getLastID();
+  String getLastIDstr(bool ashex = true);
+  String getLastMessagestr(bool ashex = true);
+  String LastMessageDecoded();
 
-    bool addRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2);
-    bool addRFDevice(uint32_t ID);
-    bool removeRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2);
-    bool removeRFDevice(uint32_t ID);
-    bool checkRFDevice(uint8_t byte0, uint8_t byte1, uint8_t byte2);
-    bool checkRFDevice(uint32_t ID);
-    void setBindAllowed(bool input) {
-      bindAllowed = input;
-    }
-    bool getBindAllowed() {
-      return bindAllowed;
-    }
-    void setAllowAll(bool input) {
-      allowAll = input;
-    }
-    bool getAllowAll() {
-      return allowAll;
-    }
-    const struct ithoRFDevices &getRFdevices() const {
-      return ithoRF;
-    }    
-    //receive
-    uint8_t receivePacket();  //read RX fifo
-    bool checkForNewPacket();
-    IthoPacket getLastPacket() {
-      return inIthoPacket;  //retrieve last received/parsed packet from remote
-    }
-    IthoCommand getLastCommand() {
-      return inIthoPacket.command;  //retrieve last received/parsed command from remote
-    }
-    uint8_t getLastInCounter() {
-      return inIthoPacket.counter;  //retrieve last received/parsed command from remote
-    }
-    uint8_t ReadRSSI();
-    bool checkID(const uint8_t *id);
-    int * getLastID();
-    String getLastIDstr(bool ashex = true);
-    String getLastMessagestr(bool ashex = true);
-    String LastMessageDecoded();
+  // send
+  void sendCommand(IthoCommand command);
 
-    //send
-    void sendCommand(IthoCommand command);
+  void handleBind();
+  void handleLevel();
+  void handleTimer();
+  void handleStatus();
+  void handleRemotestatus();
+  void handleTemphum();
+  void handleCo2();
+  void handleBattery();
 
+  const char *rem_cmd_to_name(IthoCommand code);
 
-    void handleBind();
-    void handleLevel();
-    void handleTimer();
-    void handleStatus();
-    void handleRemotestatus();
-    void handleTemphum();
-    void handleCo2();
-    void handleBattery();
+protected:
+private:
+  IthoCC1101(const IthoCC1101 &c);
+  IthoCC1101 &operator=(const IthoCC1101 &c);
 
-  protected:
-  private:
-    IthoCC1101( const IthoCC1101 &c);
-    IthoCC1101& operator=( const IthoCC1101 &c);
+  // init CC1101 for receiving
+  void initReceiveMessage();
 
-    //init CC1101 for receiving
-    void initReceiveMessage();
+  // init CC1101 for sending
+  void initSendMessage(uint8_t len);
+  void finishTransfer();
 
-    //init CC1101 for sending
-    void initSendMessage(uint8_t len);
-    void finishTransfer();
+  // parse received message
+  bool parseMessageCommand();
+  bool checkIthoCommand(IthoPacket *itho, const uint8_t commandBytes[]);
 
-    //parse received message
-    bool parseMessageCommand();
-    bool checkIthoCommand(IthoPacket *itho, const uint8_t commandBytes[]);
+  // send
+  void createMessageStart(IthoPacket *itho, CC1101Packet *packet);
+  void createMessageCommand(IthoPacket *itho, CC1101Packet *packet);
+  void createMessageJoin(IthoPacket *itho, CC1101Packet *packet);
+  void createMessageLeave(IthoPacket *itho, CC1101Packet *packet);
+  const uint8_t *getMessageCommandBytes(IthoCommand command);
+  uint8_t getCounter2(IthoPacket *itho, uint8_t len);
 
-    //send
-    void createMessageStart(IthoPacket *itho, CC1101Packet *packet);
-    void createMessageCommand(IthoPacket *itho, CC1101Packet *packet);
-    void createMessageJoin(IthoPacket *itho, CC1101Packet *packet);
-    void createMessageLeave(IthoPacket *itho, CC1101Packet *packet);
-    uint8_t* getMessageCommandBytes(IthoCommand command);
-    uint8_t getCounter2(IthoPacket *itho, uint8_t len);
+  uint8_t messageEncode(IthoPacket *itho, CC1101Packet *packet);
+  void messageDecode(CC1101Packet *packet, IthoPacket *itho);
 
-    uint8_t messageEncode(IthoPacket *itho, CC1101Packet *packet);
-    void messageDecode(CC1101Packet *packet, IthoPacket *itho);
-
-
-}; //IthoCC1101
+}; // IthoCC1101

--- a/Master/Itho/IthoPacket.h
+++ b/Master/Itho/IthoPacket.h
@@ -1,49 +1,126 @@
 /*
- * Author: Klusjesman, supersjimmie, modified and reworked by arjenhiemstra 
- */
+   Author: Klusjesman, supersjimmie, modified and reworked by arjenhiemstra
+*/
 
-#ifndef ITHOPACKET_H_
-#define ITHOPACKET_H_
+#pragma once
+
+#include <stdint.h>
 
 enum IthoCommand
-{    
+{
   IthoUnknown = 0,
-    
+
   IthoJoin = 1,
   IthoLeave = 2,
-        
+
   IthoStandby = 3,
   IthoLow = 4,
   IthoMedium = 5,
   IthoHigh = 6,
   IthoFull = 7,
-  
+
   IthoTimer1 = 8,
   IthoTimer2 = 9,
   IthoTimer3 = 10,
-  
-  //duco c system remote
-  DucoStandby = 11,
-  DucoLow = 12,
-  DucoMedium = 13,
-  DucoHigh = 14
+
+  //  //duco c system remote
+  //  DucoStandby = 11,
+  //  DucoLow = 12,
+  //  DucoMedium = 13,
+  //  DucoHigh = 14
 };
 
+enum message_state {
+  S_START,
+  S_HEADER,
+  S_ADDR0,
+  S_ADDR1,
+  S_ADDR2,
+  S_PARAM0,
+  S_PARAM1,
+  S_OPCODE,
+  S_LEN,
+  S_PAYLOAD,
+  S_CHECKSUM,
+  S_TRAILER,
+  S_COMPLETE,
+  S_ERROR
+};
+
+
+
+#define F_MASK  0x03
+#define F_RQ    0x00
+#define F_I     0x01
+#define F_W     0x02
+#define F_RP    0x03
+
+#define F_ADDR0  0x10
+#define F_ADDR1  0x20
+#define F_ADDR2  0x40
+
+#define F_PARAM0 0x04
+#define F_PARAM1 0x08
+#define F_RSSI   0x80
+
+// Only used for received fields
+#define F_OPCODE 0x01
+#define F_LEN    0x02
+
+
+#define MAX_PAYLOAD 64
+#define MAX_DECODED MAX_PAYLOAD+18
+
+static char const * const MsgType[4] = { "RQ", " W", " I", "RP" };
 
 class IthoPacket
 {
   public:
+    enum Type : uint32_t {
+      BIND          = 0x1FC9,
+      LEVEL         = 0x22F1,
+      TIMER         = 0x22F3,
+      SETPOINT      = 0x22F8,
+      STATUS        = 0x31DA,
+      REMOTESTATUS  = 0x31E0,
+      TEMPHUM       = 0x12A0,
+      CO2           = 0x1298,
+      BATTERY       = 0x1060
+    };
+
     IthoCommand command;
 
-    uint8_t dataDecoded[32];
-    uint8_t dataDecodedChk[32];
+    int8_t state;
+
+    //Message Fields
+    //<HEADER> <addr0> <addr1> <addr2> <param0> <param1> <OPCODE> <LENGTH> <PAYLOAD> <CHECKSUM>
+    //<  1   > <  3  > <  3  > <  3  > <  1   > <  1   > <  2   > <  1   > <length > <   1    >
+
+    uint8_t header;
+    uint8_t type;
+    uint32_t deviceId0;
+    uint32_t deviceId1;
+    uint32_t deviceId2;
+    uint8_t param0;
+    uint8_t param1;
+    uint16_t opcode;
+    uint8_t len;
+
+    uint8_t error;
+
+    uint8_t payloadPos;
+    uint8_t payload[MAX_PAYLOAD];
+
+    uint8_t dataDecoded[MAX_DECODED];
+    uint8_t dataDecodedChk[MAX_DECODED];
     uint8_t length;
-    
+
     uint8_t deviceType;
     uint8_t deviceId[3];
-    
+
     uint8_t counter;    //0-255, counter is increased on every remote button press
+
+    //Type getType(uint16_t opcode) const;
+
+
 };
-
-
-#endif /* ITHOPACKET_H_ */

--- a/Master/Itho/IthoPacket.h
+++ b/Master/Itho/IthoPacket.h
@@ -7,33 +7,32 @@
 
 enum IthoCommand
 {    
-	IthoUnknown = 0,
-		
-	IthoJoin = 1,
-	IthoLeave = 2,
-				
-	IthoStandby = 3,
-	IthoLow = 4,
-	IthoMedium = 5,
-	IthoHigh = 6,
-	IthoFull = 7,
-	
-	IthoTimer1 = 8,
-	IthoTimer2 = 9,
-	IthoTimer3 = 10,
-	
-	//duco c system remote
-	DucoStandby = 11,
-	DucoLow = 12,
-	DucoMedium = 13,
-	DucoHigh = 14
+  IthoUnknown = 0,
+    
+  IthoJoin = 1,
+  IthoLeave = 2,
+        
+  IthoStandby = 3,
+  IthoLow = 4,
+  IthoMedium = 5,
+  IthoHigh = 6,
+  
+  IthoTimer1 = 8,
+  IthoTimer2 = 9,
+  IthoTimer3 = 10,
+  
+  //duco c system remote
+  DucoStandby = 11,
+  DucoLow = 12,
+  DucoMedium = 13,
+  DucoHigh = 14
 };
 
 
 class IthoPacket
 {
-	public:
-		IthoCommand command;
+  public:
+    IthoCommand command;
 
     uint8_t dataDecoded[32];
     uint8_t dataDecodedChk[32];
@@ -42,7 +41,7 @@ class IthoPacket
     uint8_t deviceType;
     uint8_t deviceId[3];
     
-		uint8_t counter;		//0-255, counter is increased on every remote button press
+    uint8_t counter;    //0-255, counter is increased on every remote button press
 };
 
 

--- a/Master/Itho/IthoPacket.h
+++ b/Master/Itho/IthoPacket.h
@@ -16,6 +16,7 @@ enum IthoCommand
   IthoLow = 4,
   IthoMedium = 5,
   IthoHigh = 6,
+  IthoFull = 7,
   
   IthoTimer1 = 8,
   IthoTimer2 = 9,

--- a/Master/Itho/IthoPacket.h
+++ b/Master/Itho/IthoPacket.h
@@ -36,6 +36,7 @@ class IthoPacket
 		IthoCommand command;
 
     uint8_t dataDecoded[32];
+    uint8_t dataDecodedChk[32];
     uint8_t length;
     
     uint8_t deviceType;

--- a/Master/Itho/IthoPacket.h
+++ b/Master/Itho/IthoPacket.h
@@ -1,54 +1,46 @@
 /*
- * Author: Klusjesman, modified bij supersjimmie for Arduino/ESP8266
+ * Author: Klusjesman, supersjimmie, modified and reworked by arjenhiemstra 
  */
 
 #ifndef ITHOPACKET_H_
 #define ITHOPACKET_H_
 
-
-typedef enum IthoMessageType
- {
- 	ithomsg_unknown = 0,
- 	ithomsg_control = 1,
- 	ithomsg_join = 2,
- 	ithomsg_leave = 3
- };
- 
- //do not change enum because they are used in calculations!
 enum IthoCommand
-{
+{    
 	IthoUnknown = 0,
 		
-	IthoJoin = 4,
-	IthoLeave = 8,
+	IthoJoin = 1,
+	IthoLeave = 2,
 				
-	IthoStandby = 34,
-	IthoLow = 35,	
-	IthoMedium = 36,	
-	IthoHigh = 37,
-	IthoFull = 38,
+	IthoStandby = 3,
+	IthoLow = 4,
+	IthoMedium = 5,
+	IthoHigh = 6,
+	IthoFull = 7,
 	
-	IthoTimer1 = 41,
-	IthoTimer2 = 51,
-	IthoTimer3 = 61,
+	IthoTimer1 = 8,
+	IthoTimer2 = 9,
+	IthoTimer3 = 10,
 	
 	//duco c system remote
-	DucoStandby = 251,
-	DucoLow = 252,
-	DucoMedium = 253,
-	DucoHigh = 254
+	DucoStandby = 11,
+	DucoLow = 12,
+	DucoMedium = 13,
+	DucoHigh = 14
 };
 
 
 class IthoPacket
 {
 	public:
-		uint8_t deviceId1[6];
-		uint8_t deviceId2[8];
-		IthoMessageType messageType;
 		IthoCommand command;
-		IthoCommand previous;
-		
+
+    uint8_t dataDecoded[32];
+    uint8_t length;
+    
+    uint8_t deviceType;
+    uint8_t deviceId[3];
+    
 		uint8_t counter;		//0-255, counter is increased on every remote button press
 };
 

--- a/Master/Itho/IthoPacket.h
+++ b/Master/Itho/IthoPacket.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 enum IthoCommand
 {
@@ -13,7 +13,7 @@ enum IthoCommand
   IthoJoin = 1,
   IthoLeave = 2,
 
-  IthoStandby = 3,
+  IthoAway = 3,
   IthoLow = 4,
   IthoMedium = 5,
   IthoHigh = 6,
@@ -23,14 +23,16 @@ enum IthoCommand
   IthoTimer2 = 9,
   IthoTimer3 = 10,
 
-  //  //duco c system remote
-  //  DucoStandby = 11,
-  //  DucoLow = 12,
-  //  DucoMedium = 13,
-  //  DucoHigh = 14
+  IthoAuto = 11,
+  IthoAutoNight = 12,
+
+  IthoCook30 = 13,
+  IthoCook60 = 14,
+
 };
 
-enum message_state {
+enum message_state
+{
   S_START,
   S_HEADER,
   S_ADDR0,
@@ -47,80 +49,152 @@ enum message_state {
   S_ERROR
 };
 
+enum RemoteTypes : uint16_t
+{
+  UNSETTYPE = 0x0000,
+  RFTCVE = 0x22F1,
+  RFTAUTO = 0x22F3,
+  DEMANDFLOW = 0x22F8,
+  RFTRV = 0x12A0,
+  RFTCO2 = 0x1298,
+  ORCON15LF01 = 0x6710
+};
 
+#define F_MASK 0x03
+#define F_RQ 0x00
+#define F_I 0x01
+#define F_W 0x02
+#define F_RP 0x03
 
-#define F_MASK  0x03
-#define F_RQ    0x00
-#define F_I     0x01
-#define F_W     0x02
-#define F_RP    0x03
-
-#define F_ADDR0  0x10
-#define F_ADDR1  0x20
-#define F_ADDR2  0x40
+#define F_ADDR0 0x10
+#define F_ADDR1 0x20
+#define F_ADDR2 0x40
 
 #define F_PARAM0 0x04
 #define F_PARAM1 0x08
-#define F_RSSI   0x80
+#define F_RSSI 0x80
 
 // Only used for received fields
 #define F_OPCODE 0x01
-#define F_LEN    0x02
-
+#define F_LEN 0x02
 
 #define MAX_PAYLOAD 64
-#define MAX_DECODED MAX_PAYLOAD+18
+#define MAX_DECODED MAX_PAYLOAD + 18
 
-static char const * const MsgType[4] = { "RQ", " W", " I", "RP" };
+static char const *const MsgType[4] = {"RQ", "_W", "_I", "RP"};
+
+// General command structure:
+// < opcode 2 bytes >< len 1 byte >< command len bytes >
+
+// message command bytes for CVE/HRU remote (536-0124)
+const uint8_t ithoMessageAwayCommandBytes[] = {0x22, 0xF1, 0x03, 0x00, 0x01, 0x04};
+const uint8_t ithoMessageLowCommandBytes[] = {0x22, 0xF1, 0x03, 0x00, 0x02, 0x04};
+const uint8_t ithoMessageMediumCommandBytes[] = {0x22, 0xF1, 0x03, 0x00, 0x03, 0x04};
+const uint8_t ithoMessageHighCommandBytes[] = {0x22, 0xF1, 0x03, 0x00, 0x04, 0x04};
+const uint8_t ithoMessageFullCommandBytes[] = {0x22, 0xF1, 0x03, 0x00, 0x04, 0x04};
+const uint8_t ithoMessageTimer1CommandBytes[] = {0x22, 0xF3, 0x03, 0x00, 0x00, 0x0A}; // 10 minutes full speed
+const uint8_t ithoMessageTimer2CommandBytes[] = {0x22, 0xF3, 0x03, 0x00, 0x00, 0x14}; // 20 minutes full speed
+const uint8_t ithoMessageTimer3CommandBytes[] = {0x22, 0xF3, 0x03, 0x00, 0x00, 0x1E}; // 30 minutes full speed
+
+// message command bytes specific for AUTO RFT (536-0150)
+const uint8_t ithoMessageAUTORFTLowCommandBytes[] = {0x22, 0xF1, 0x03, 0x63, 0x02, 0x04};
+const uint8_t ithoMessageAUTORFTAutoCommandBytes[] = {0x22, 0xF1, 0x03, 0x63, 0x03, 0x04};
+const uint8_t ithoMessageAUTORFTAutoNightCommandBytes[] = {0x22, 0xF8, 0x03, 0x63, 0x02, 0x03};
+const uint8_t ithoMessageAUTORFTHighCommandBytes[] = {0x22, 0xF1, 0x03, 0x63, 0x04, 0x04};
+const uint8_t ithoMessageAUTORFTTimer1CommandBytes[] = {0x22, 0xF3, 0x03, 0x63, 0x00, 0x0A};
+const uint8_t ithoMessageAUTORFTTimer2CommandBytes[] = {0x22, 0xF3, 0x03, 0x63, 0x00, 0x14};
+const uint8_t ithoMessageAUTORFTTimer3CommandBytes[] = {0x22, 0xF3, 0x03, 0x63, 0x00, 0x1E};
+
+// message command bytes specific for RFT-RV (04-00046) and RFT-CO2  (04-00045)
+const uint8_t ithoMessageRV_CO2MediumCommandBytes[] = {0x22, 0xF1, 0x03, 0x00, 0x03, 0x07};
+const uint8_t ithoMessageRV_CO2AutoCommandBytes[] = {0x22, 0xF1, 0x03, 0x00, 0x05, 0x07};
+const uint8_t ithoMessageRV_CO2AutoNightCommandBytes[] = {0x22, 0xF1, 0x03, 0x00, 0x0B, 0x0B};
+const uint8_t ithoMessageRV_CO2Timer1CommandBytes[] = {0x22, 0xF3, 0x07, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x00, 0x00};
+const uint8_t ithoMessageRV_CO2Timer2CommandBytes[] = {0x22, 0xF3, 0x07, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00, 0x00};
+const uint8_t ithoMessageRV_CO2Timer3CommandBytes[] = {0x22, 0xF3, 0x07, 0x00, 0x00, 0x1E, 0x00, 0x00, 0x00, 0x00};
+
+// message command bytes specific for DemandFlow remote (536-0146)
+const uint8_t ithoMessageDFLowCommandBytes[] = {0x22, 0xF8, 0x03, 0x00, 0x01, 0x02};
+const uint8_t ithoMessageDFHighCommandBytes[] = {0x22, 0xF8, 0x03, 0x00, 0x02, 0x02};
+const uint8_t ithoMessageDFTimer1CommandBytes[] = {0x22, 0xF3, 0x05, 0x00, 0x42, 0x03, 0x03, 0x03};
+const uint8_t ithoMessageDFTimer2CommandBytes[] = {0x22, 0xF3, 0x05, 0x00, 0x42, 0x06, 0x03, 0x03};
+const uint8_t ithoMessageDFTimer3CommandBytes[] = {0x22, 0xF3, 0x05, 0x00, 0x42, 0x09, 0x03, 0x03};
+const uint8_t ithoMessageDFCook30CommandBytes[] = {0x22, 0xF3, 0x05, 0x00, 0x02, 0x1E, 0x02, 0x03};
+const uint8_t ithoMessageDFCook60CommandBytes[] = {0x22, 0xF3, 0x05, 0x00, 0x02, 0x3C, 0x02, 0x03};
+
+// Join/Leave command structure:
+// < opcode 2 bytes >< len 1 byte >[next command + device ID block repeats len/6 times]< command 3 bytes >< device ID 3 bytes >
+
+// Join/Leave commands:
+const uint8_t ithoMessageCVERFTJoinCommandBytes[] = {0x1F, 0xC9, 0x0C, 0x00, 0x22, 0xF1, 0x00, 0x00, 0x00, 0x01, 0x10, 0xE0, 0x00, 0x00, 0x00};                                                                                                          // join command of CVE/HRU remote (536-0124)
+const uint8_t ithoMessageAUTORFTJoinCommandBytes[] = {0x1F, 0xC9, 0x0C, 0x63, 0x22, 0xF8, 0x00, 0x00, 0x00, 0x01, 0x10, 0xE0, 0x00, 0x00, 0x00};                                                                                                         // join command of AUTO RFT (536-0150)
+const uint8_t ithoMessageDFJoinCommandBytes[] = {0x1F, 0xC9, 0x0C, 0x00, 0x22, 0xF8, 0x00, 0x00, 0x00, 0x00, 0x10, 0xE0, 0x00, 0x00, 0x00};                                                                                                              // join command of DemandFlow remote (536-0146)
+const uint8_t ithoMessageRVJoinCommandBytes[] = {0x1F, 0xC9, 0x18, 0x00, 0x31, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x12, 0xA0, 0x00, 0x00, 0x00, 0x01, 0x10, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x1F, 0xC9, 0x00, 0x00, 0x00};                                      // join command of RFT-RV (04-00046)
+const uint8_t ithoMessageCO2JoinCommandBytes[] = {0x1F, 0xC9, 0x1E, 0x00, 0x31, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x12, 0x98, 0x00, 0x00, 0x00, 0x00, 0x2E, 0x10, 0x00, 0x00, 0x00, 0x01, 0x10, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x1F, 0xC9, 0x00, 0x00, 0x00}; // join command of RFT-CO2  (04-00045)
+const uint8_t ithoMessageLeaveCommandBytes[] = {0x1F, 0xC9, 0x06, 0x00, 0x1F, 0xC9, 0x00, 0x00, 0x00};                                                                                                                                                   // standard leave command
+const uint8_t ithoMessageAUTORFTLeaveCommandBytes[] = {0x1F, 0xC9, 0x06, 0x63, 0x1F, 0xC9, 0x00, 0x00, 0x00};                                                                                                                                            // leave command of AUTO RFT (536-0150)
+
+// Orcon remote VMN-15LF01
+const uint8_t orconMessageAwayCommandBytes[] = {0x22, 0xF1, 0x03, 0x00, 0x00, 0x04};
+const uint8_t orconMessageAutoCommandBytes[] = {0x22, 0xF1, 0x03, 0x00, 0x04, 0x04};
+const uint8_t orconMessageButton1CommandBytes[] = {0x22, 0xF1, 0x03, 0x00, 0x01, 0x04};
+const uint8_t orconMessageButton2CommandBytes[] = {0x22, 0xF1, 0x03, 0x00, 0x02, 0x04};
+const uint8_t orconMessageButton3CommandBytes[] = {0x22, 0xF1, 0x03, 0x00, 0x03, 0x04};
+const uint8_t orconMessageTimer1CommandBytes[] = {0x22, 0xF3, 0x07, 0x00, 0x02, 0x0F, 0x03, 0x04, 0x00, 0x00};
+const uint8_t orconMessageTimer2CommandBytes[] = {0x22, 0xF3, 0x07, 0x00, 0x02, 0x1E, 0x03, 0x04, 0x00, 0x00};
+const uint8_t orconMessageTimer3CommandBytes[] = {0x22, 0xF3, 0x07, 0x00, 0x02, 0x3C, 0x03, 0x04, 0x00, 0x00};
+const uint8_t orconMessageFilterCleanCommandBytes[] = {0x10, 0xD0, 0x02, 0x00, 0xFF};
+const uint8_t orconMessageJoinCommandBytes[] = {0x1F, 0xC9, 0x12, 0x00, 0x22, 0xF1, 0x00, 0x00, 0x00, 0x00, 0x22, 0xF3, 0x00, 0x00, 0x00, 0x67, 0x10, 0xE0, 0x00, 0x00, 0x00};
+const uint8_t orconMessageBatteryStatusCommandBytes[] = {0x10, 0x60, 0x03, 0x00, 0xFF, 0x01};
 
 class IthoPacket
 {
-  public:
-    enum Type : uint32_t {
-      BIND          = 0x1FC9,
-      LEVEL         = 0x22F1,
-      TIMER         = 0x22F3,
-      SETPOINT      = 0x22F8,
-      STATUS        = 0x31DA,
-      REMOTESTATUS  = 0x31E0,
-      TEMPHUM       = 0x12A0,
-      CO2           = 0x1298,
-      BATTERY       = 0x1060
-    };
+public:
+  enum Type : uint32_t
+  {
+    BIND = 0x1FC9,
+    LEVEL = 0x22F1,
+    TIMER = 0x22F3,
+    SETPOINT = 0x22F8,
+    STATUS = 0x31DA,
+    REMOTESTATUS = 0x31E0,
+    TEMPHUM = 0x12A0,
+    CO2 = 0x1298,
+    BATTERY = 0x1060
+  };
 
-    IthoCommand command;
+  RemoteTypes remType;
+  IthoCommand command;
 
-    int8_t state;
+  int8_t state;
 
-    //Message Fields
-    //<HEADER> <addr0> <addr1> <addr2> <param0> <param1> <OPCODE> <LENGTH> <PAYLOAD> <CHECKSUM>
-    //<  1   > <  3  > <  3  > <  3  > <  1   > <  1   > <  2   > <  1   > <length > <   1    >
+  // Message Fields
+  //<HEADER> <addr0> <addr1> <addr2> <param0> <param1> <OPCODE> <LENGTH> <PAYLOAD> <CHECKSUM>
+  //<  1   > <  3  > <  3  > <  3  > <  1   > <  1   > <  2   > <  1   > <length > <   1    >
 
-    uint8_t header;
-    uint8_t type;
-    uint32_t deviceId0;
-    uint32_t deviceId1;
-    uint32_t deviceId2;
-    uint8_t param0;
-    uint8_t param1;
-    uint16_t opcode;
-    uint8_t len;
+  uint8_t header;
+  uint8_t type;
+  uint32_t deviceId0;
+  uint32_t deviceId1;
+  uint32_t deviceId2;
+  uint8_t param0;
+  uint8_t param1;
+  uint16_t opcode;
+  uint8_t len;
 
-    uint8_t error;
+  uint8_t error;
 
-    uint8_t payloadPos;
-    uint8_t payload[MAX_PAYLOAD];
+  uint8_t payloadPos;
+  uint8_t payload[MAX_PAYLOAD];
 
-    uint8_t dataDecoded[MAX_DECODED];
-    uint8_t dataDecodedChk[MAX_DECODED];
-    uint8_t length;
+  uint8_t dataDecoded[MAX_DECODED];
+  uint8_t dataDecodedChk[MAX_DECODED];
+  uint8_t length;
 
-    uint8_t deviceType;
-    uint8_t deviceId[3];
+  uint8_t deviceType;
+  uint8_t deviceId[3];
 
-    uint8_t counter;    //0-255, counter is increased on every remote button press
+  uint8_t counter; // 0-255, counter is increased on every remote button press
 
-    //Type getType(uint16_t opcode) const;
-
-
+  // Type getType(uint16_t opcode) const;
 };

--- a/Master/IthoEcoFanRFT/IthoEcoFanRFT.ino
+++ b/Master/IthoEcoFanRFT/IthoEcoFanRFT.ino
@@ -81,13 +81,17 @@ void loop(void) {
   }
 }
 
+#if defined (ESP8266) && defined (ESP32)
 ICACHE_RAM_ATTR void ITHOcheck() {
+#else
+void ITHOcheck() {
+#endif
   ITHOhasPacket = true;
 }
 
 void showPacket() {
   ITHOhasPacket = false;
-  uint8_t goodpos = findRFTlastCommand();
+  int8_t goodpos = findRFTlastCommand();
   if (goodpos != -1)  RFTlastCommand = RFTcommand[goodpos];
   else                RFTlastCommand = IthoUnknown;
   //show data
@@ -122,6 +126,9 @@ void showPacket() {
     case IthoUnknown:
       Serial.print("unknown\n");
       break;
+    case IthoStandby:
+      Serial.print("standby\n");
+      break;      
     case IthoLow:
       Serial.print("low\n");
       break;

--- a/Master/IthoEcoFanRFT/IthoEcoFanRFT.ino
+++ b/Master/IthoEcoFanRFT/IthoEcoFanRFT.ino
@@ -14,6 +14,7 @@
    Added ICACHE_RAM_ATTR to 'void ITHOcheck()' for ESP8266/ESP32 compatibility
    Trigger on the falling edge and simplified ISR routine for more robust packet handling
    Move SYNC word from 171,170 further down the message to 179,42,163,42 to filter out more non-itho messages in CC1101 hardware
+   Check validity of incoming message
    
    Tested on ESP8266 & ESP32   
 */

--- a/Master/IthoEcoFanRFT/IthoEcoFanRFT.ino
+++ b/Master/IthoEcoFanRFT/IthoEcoFanRFT.ino
@@ -1,15 +1,21 @@
 /*
-   Original Author: Klusjesman
+   Original Author: Klusjesman & supersjimmie
 
    Tested with STK500 + ATMega328P
    GCC-AVR compiler
 
-   Modified by supersjimmie:
-   Code and libraries made compatible with Arduino and ESP8266
-   Tested with Arduino IDE v1.6.5 and 1.6.9
-   For ESP8266 tested with ESP8266 core for Arduino v 2.1.0 and 2.2.0 Stable
-   (See https://github.com/esp8266/Arduino/ )
-
+   Modified by arjenhiemstra:
+   Complete rework of the itho packet section, cleanup and easier to understand
+   Library structure is preserved, should be a drop in replacement (apart from device id) 
+   Decode incoming messages to direct usable decimals without further bit-shifting
+   DeviceID is now 3 bytes long and can be set during runtime
+   Counter2 is the decimal sum of all bytes in decoded form from deviceType up to the last byte before counter2 subtracted from zero.
+   Encode outgoing messages in itho compatible format
+   Added ICACHE_RAM_ATTR to 'void ITHOcheck()' for ESP8266/ESP32 compatibility
+   Trigger on the falling edge and simplified ISR routine for more robust packet handling
+   Move SYNC word from 171,170 further down the message to 179,42,163,42 to filter out more non-itho messages in CC1101 hardware
+   
+   Tested on ESP8266 & ESP32   
 */
 
 /*
@@ -27,15 +33,13 @@
 #include <SPI.h>
 #include "IthoCC1101.h"
 #include "IthoPacket.h"
-#include <Ticker.h>
 
-#define ITHO_IRQ_PIN D2
+#define ITHO_IRQ_PIN 4 //D2(GPIO4) on NodeMCU
 
 IthoCC1101 rf;
 IthoPacket packet;
-Ticker ITHOticker;
 
-const uint8_t RFTid[] = {106, 170, 106, 101, 154, 107, 154, 86}; // my ID
+const uint8_t RFTid[] = {11, 22, 33}; // my ID
 
 bool ITHOhasPacket = false;
 IthoCommand RFTcommand[3] = {IthoUnknown, IthoUnknown, IthoUnknown};
@@ -50,37 +54,34 @@ void setup(void) {
   Serial.begin(115200);
   delay(500);
   Serial.println("setup begin");
+  rf.setDeviceID(13, 123, 42); //DeviceID used to send commands, can also be changed on the fly for multi itho control
   rf.init();
   Serial.println("setup done");
   sendRegister();
   Serial.println("join command sent");
   pinMode(ITHO_IRQ_PIN, INPUT);
-  attachInterrupt(ITHO_IRQ_PIN, ITHOinterrupt, RISING);
+  attachInterrupt(ITHO_IRQ_PIN, ITHOcheck, FALLING);
 }
 
 void loop(void) {
   // do whatever you want, check (and reset) the ITHOhasPacket flag whenever you like
   if (ITHOhasPacket) {
-    showPacket();
-  }
-}
-
-void ITHOinterrupt() {
-  ITHOticker.once_ms(10, ITHOcheck);
-}
-
-void ITHOcheck() {
-  if (rf.checkForNewPacket()) {
-    IthoCommand cmd = rf.getLastCommand();
-    if (++RFTcommandpos > 2) RFTcommandpos = 0;  // store information in next entry of ringbuffers
-    RFTcommand[RFTcommandpos] = cmd;
-    RFTRSSI[RFTcommandpos]    = rf.ReadRSSI();
-    bool chk = rf.checkID(RFTid);
-    RFTidChk[RFTcommandpos]   = chk;
-    if ((cmd != IthoUnknown) && chk) {  // only act on good cmd and correct id.
-      ITHOhasPacket = true;
+    if (rf.checkForNewPacket()) {
+      IthoCommand cmd = rf.getLastCommand();
+      if (++RFTcommandpos > 2) RFTcommandpos = 0;  // store information in next entry of ringbuffers
+      RFTcommand[RFTcommandpos] = cmd;
+      RFTRSSI[RFTcommandpos]    = rf.ReadRSSI();
+      bool chk = rf.checkID(RFTid);
+      RFTidChk[RFTcommandpos]   = chk;
+      if ((cmd != IthoUnknown)) {  // only act on good cmd and correct id.
+        showPacket();
+      }
     }
   }
+}
+
+ICACHE_RAM_ATTR void ITHOcheck() {
+  ITHOhasPacket = true;
 }
 
 void showPacket() {
@@ -112,7 +113,7 @@ void showPacket() {
   Serial.print(F(" "));
   Serial.print(RFTidChk[2]);
   Serial.print(F(" / Last ID: "));
-  Serial.print(rf.getLastIDstr());
+  Serial.print(rf.getLastIDstr(false));
 
   Serial.print(F(" / Command = "));
   //show command

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Complete rework of the itho packet section, cleanup and easier to understand, im
 *  Move SYNC word from 171,170 further down the message to 179,42,163,42 to filter out more non-itho messages in CC1101 hardware
 *  Support for RFT-CO2 and RFT-RV devices (monitor values and commands)
 
-   Tested on ESP8266 & ESP32
+   Tested on ESP8266 & ESP32, compiles on Arduino Uno but might be memory heavy
 ```
 
 Will work with a 868MHz CC1101 module.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Complete rework of the itho packet section, cleanup and easier to understand, im
 *  Added ICACHE_RAM_ATTR to 'void ITHOcheck()' for ESP8266/ESP32 compatibility
 *  Trigger on the falling edge and simplified ISR routine for more robust packet handling
 *  Move SYNC word from 171,170 further down the message to 179,42,163,42 to filter out more non-itho messages in CC1101 hardware
+*  Support for RFT-CO2 and RFT-RV devices (monitor values and commands)
 
    Tested on ESP8266 & ESP32
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # IthoEcoFanRFT
-Cloned from Klusjesman, modified to work on Arduino and ESP8266 with Arduino IDE
+Cloned from supersjimmie which cloned from Klusjesman, 
+
+Complete rework of the itho packet section, cleanup and easier to understand, improved stability
+```
+*  Library structure is preserved, should be a drop in replacement (apart from device id)
+*  Decode incoming messages to direct usable decimals without further bit-shifting
+*  DeviceID is now 3 bytes long and can be set during runtime
+*  Counter2 is now the decimal sum of all bytes in decoded form from deviceType up to the last byte before counter2 subtracted from zero.
+*  Encode outgoing messages in itho compatible format
+*  Added ICACHE_RAM_ATTR to 'void ITHOcheck()' for ESP8266/ESP32 compatibility
+*  Trigger on the falling edge and simplified ISR routine for more robust packet handling
+*  Move SYNC word from 171,170 further down the message to 179,42,163,42 to filter out more non-itho messages in CC1101 hardware
+
+   Tested on ESP8266 & ESP32
+```
 
 Will work with a 868MHz CC1101 module.
 The CC1150 may also work, except for receiving (which is not required for controlling an Itho EcoFan).


### PR DESCRIPTION
Complete rework of the itho packet section, cleanup and easier to understand, improved stability
```
*  Library structure is preserved, should be a drop in replacement (apart from device id)
*  Decode incoming messages to direct usable decimals without further bit-shifting
*  DeviceID is now 3 bytes long and can be set during runtime
*  Counter2 is now the decimal sum of all bytes in decoded form from deviceType up to the last byte before counter2 subtracted from zero.
*  Encode outgoing messages in itho compatible format
*  Added ICACHE_RAM_ATTR to 'void ITHOcheck()' for ESP8266/ESP32 compatibility
*  Trigger on the falling edge and simplified ISR routine for more robust packet handling
*  Move SYNC word from 171,170 further down the message to 179,42,163,42 to filter out more non-itho messages in CC1101 hardware
   Tested on ESP8266 & ESP32
```